### PR TITLE
Adding new line after "error:" and "warning:".

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/util/ErrorUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/ErrorUtil.java
@@ -38,6 +38,7 @@ public class ErrorUtil {
   private static String currentFileName = null;
   private static PrintStream errorStream = System.err;
   private static List<String> errorMessages = Lists.newArrayList();
+  private static final String LINE_FEED = System.getProperty("line.separator");
 
   public static void reset() {
     errorCount = 0;
@@ -73,13 +74,17 @@ public class ErrorUtil {
   }
 
   public static void error(String message) {
-    errorMessages.add(message);
-    errorStream.println("error: " + message);
+    // Adding a new line so as to preserve the original message format.
+    String fullMessage = "error:" + LINE_FEED + message;
+    errorMessages.add(fullMessage);
+    errorStream.println(fullMessage);
     errorCount++;
   }
 
   public static void warning(String message) {
-    errorStream.println("warning: " + message);
+    // Adding a new line so as to preserve the original message format.
+    String fullMessage = "warning:" + LINE_FEED + message;
+    errorStream.println(fullMessage);
     warningCount++;
   }
 

--- a/translator/src/main/java/com/google/devtools/j2objc/util/ErrorUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/ErrorUtil.java
@@ -75,6 +75,8 @@ public class ErrorUtil {
 
   public static void error(String message) {
     // Adding a new line so as to preserve the original message format.
+    // If the original message happens to start with "<file>:<line>: ",
+    // Xcode will be able to pick it up.
     String fullMessage = "error:" + LINE_FEED + message;
     errorMessages.add(fullMessage);
     errorStream.println(fullMessage);
@@ -83,6 +85,8 @@ public class ErrorUtil {
 
   public static void warning(String message) {
     // Adding a new line so as to preserve the original message format.
+    // If the original message happens to start with "<file>:<line>: ",
+    // Xcode will be able to pick it up.
     String fullMessage = "warning:" + LINE_FEED + message;
     errorStream.println(fullMessage);
     warningCount++;


### PR DESCRIPTION
Adding a new line so as to preserve the original message format. If the original message happens to start with "FILE:LINE: ", Xcode will be able to pick it up. For java files added to an Xcode project and configured to translate as part of the build process (just like https://github.com/tomball/j2objc-sample-reversi), we will be able to click on the error message, and it will bring us to the line with error. That make it easy to code to fix java files within Xcode.

However the new line between "error:" and the remaining message may not be desirable in some other cases. Merge with caution.

The perfect solution to this will be having error message and line number coming in as separate parameters, but that requires a much large scope change.