### PR TITLE
Whoops, missing pointer '*' in multi-catch exception translations.

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -395,7 +395,7 @@ public class StatementGenerator extends TreeVisitor {
     for (Type exceptionType : ((UnionType) exception.getType()).getTypes()) {
       buffer.append("@catch (");
       exceptionType.accept(this);
-      buffer.append(' ');
+      buffer.append(" *");
       exception.getName().accept(this);
       buffer.append(") {\n");
       printMainExceptionStore(hasResources, node);

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
@@ -1460,8 +1460,8 @@ public class StatementGeneratorTest extends GenerationTest {
         + "      else { throw new SecondException(); }"
         + "    } catch (FirstException|SecondException e) { throw e; }}}",
         "Test", "Test.m");
-    assertTranslation(translation, "@catch (Test_FirstException e) {\n    @throw e;\n  }");
-    assertTranslation(translation, "@catch (Test_SecondException e) {\n    @throw e;\n  }");
+    assertTranslation(translation, "@catch (Test_FirstException *e) {\n    @throw e;\n  }");
+    assertTranslation(translation, "@catch (Test_SecondException *e) {\n    @throw e;\n  }");
   }
 
   public void testDifferentTypesInConditionalExpression() throws IOException {


### PR DESCRIPTION
Not sure how this got missed. Maybe no one uses it. Unit test was wrong too.