### PR TITLE
Renamed IOSClass.classWithClass and classWithProtocol to IOSClass.classF...

### DIFF
--- a/jre_emul/Classes/IOSArrayClass.m
+++ b/jre_emul/Classes/IOSArrayClass.m
@@ -72,7 +72,7 @@
 
 - (IOSObjectArray *)getInterfacesWithArrayType:(IOSClass *)arrayType {
   return [IOSObjectArray arrayWithObjects:(id[]){
-        [IOSClass classWithProtocol:@protocol(JavaIoSerializable)]
+        [IOSClass classFromProtocol:@protocol(JavaIoSerializable)]
       } count:1 type:[IOSClass getClass]];
 }
 

--- a/jre_emul/Classes/IOSArrayTest.m
+++ b/jre_emul/Classes/IOSArrayTest.m
@@ -195,7 +195,7 @@
 // Objects are separately tested, because unlike primitive types, object arrays
 // need a specified element type.
 - (void)testObjectMultiDimensionalCreate {
-  IOSClass *type = [IOSClass classWithClass:[JavaUtilDate class]];
+  IOSClass *type = [IOSClass classFromClass:[JavaUtilDate class]];
 
   // Verify single dimension array is correct type.
   id array = [IOSObjectArray arrayWithDimensions:1

--- a/jre_emul/Classes/IOSClass.h
+++ b/jre_emul/Classes/IOSClass.h
@@ -52,8 +52,10 @@
 @property (readonly) Protocol *objcProtocol;
 
 // IOSClass Getters.
-+ (IOSClass *)classWithClass:(Class)cls;
-+ (IOSClass *)classWithProtocol:(Protocol *)protocol;
++ (IOSClass *)classWithClass:(Class)cls __deprecated_msg("use classFromClass instead");
++ (IOSClass *)classFromClass:(Class)cls;
++ (IOSClass *)classWithProtocol:(Protocol *)protocol __deprecated_msg("use classFromProtocol instead");
++ (IOSClass *)classFromProtocol:(Protocol *)protocol;
 + (IOSClass *)arrayClassWithComponentType:(IOSClass *)componentType;
 + (IOSClass *)classForIosName:(NSString *)iosName;
 + (IOSClass *)primitiveClassForChar:(unichar)c;

--- a/jre_emul/Classes/IOSClass.m
+++ b/jre_emul/Classes/IOSClass.m
@@ -99,7 +99,15 @@ static JavaUtilProperties *prefixMapping;
   return FetchClass(cls);
 }
 
++ (IOSClass *)classFromClass:(Class)cls {
+  return FetchClass(cls);
+}
+
 + (IOSClass *)classWithProtocol:(Protocol *)protocol {
+  return FetchProtocol(protocol);
+}
+
++ (IOSClass *)classFromProtocol:(Protocol *)protocol {
   return FetchProtocol(protocol);
 }
 
@@ -604,7 +612,7 @@ static BOOL hasModifier(IOSClass *cls, int flag) {
 
 - (IOSObjectArray *)getTypeParameters {
   IOSClass *typeVariableClass = [IOSClass
-      classWithProtocol:objc_getProtocol("JavaLangReflectTypeVariable")];
+      classFromProtocol:objc_getProtocol("JavaLangReflectTypeVariable")];
   return [IOSObjectArray arrayWithLength:0 type:typeVariableClass];
 }
 
@@ -649,7 +657,7 @@ static BOOL hasModifier(IOSClass *cls, int flag) {
     }
     cls = [cls getSuperclass];
   }
-  IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+  IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
   IOSObjectArray *result = [IOSObjectArray arrayWithNSArray:array type:annotationType];
 #if ! __has_feature(objc_arc)
   [array release];
@@ -665,7 +673,7 @@ static BOOL hasModifier(IOSClass *cls, int flag) {
       return method_invoke(cls, annotationsMethod);
     }
   }
-  IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+  IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
   return [IOSObjectArray arrayWithLength:0 type:annotationType];
 }
 
@@ -801,7 +809,7 @@ static void GetFieldsFromClass(IOSClass *iosClass, NSMutableDictionary *fields) 
 
 IOSObjectArray *copyFieldsToObjectArray(NSArray *fields) {
   jint count = (jint)[fields count];
-  IOSClass *fieldType = [IOSClass classWithClass:[JavaLangReflectField class]];
+  IOSClass *fieldType = [IOSClass classFromClass:[JavaLangReflectField class]];
   IOSObjectArray *results = [IOSObjectArray arrayWithLength:count
                                                        type:fieldType];
   for (jint i = 0; i < count; i++) {

--- a/jre_emul/Classes/IOSConcreteClass.m
+++ b/jre_emul/Classes/IOSConcreteClass.m
@@ -54,7 +54,7 @@
 - (IOSClass *)getSuperclass {
   Class superclass = [class_ superclass];
   if (superclass != nil) {
-    return [IOSClass classWithClass:superclass];
+    return [IOSClass classFromClass:superclass];
   }
   return nil;
 }
@@ -64,7 +64,7 @@
   if (!superclass) {
     return nil;
   }
-  IOSClass *rawType = [IOSClass classWithClass:superclass];
+  IOSClass *rawType = [IOSClass classFromClass:superclass];
   IOSObjectArray *typeArgs = nil;
   JavaClassMetadata *metadata = [self getMetadata];
   if (metadata) {
@@ -233,7 +233,7 @@ IOSObjectArray *getConstructorsImpl(IOSConcreteClass *clazz, BOOL publicOnly) {
     return nil;
   });
   return [IOSObjectArray arrayWithNSArray:[methodMap allValues] type:
-          [IOSClass classWithClass:[JavaLangReflectConstructor class]]];
+          [IOSClass classFromClass:[JavaLangReflectConstructor class]]];
 }
 
 - (IOSObjectArray *)getDeclaredConstructors {
@@ -304,7 +304,7 @@ static JavaLangReflectConstructor *GetConstructorImpl(
     unsigned int outCount;
     Protocol * __unsafe_unretained *interfaces = class_copyProtocolList(class_, &outCount);
     for (unsigned i = 0; i < outCount; i++) {
-      IOSClass *interface = [IOSClass classWithProtocol:interfaces[i]];
+      IOSClass *interface = [IOSClass classFromProtocol:interfaces[i]];
       NSString *name = [interface getName];
       // Don't include NSObject and JavaObject interfaces, since java.lang.Object is a class.
       if (![allInterfaces containsObject:interface] && ![name isEqualToString:@"JavaObject"] &&

--- a/jre_emul/Classes/IOSObjectArrayTest.m
+++ b/jre_emul/Classes/IOSObjectArrayTest.m
@@ -31,7 +31,7 @@
 @implementation IOSObjectArrayTest
 
 - (void)testInitialization {
-  IOSClass * elementType = [IOSClass classWithClass:[NSObject class]];
+  IOSClass * elementType = [IOSClass classFromClass:[NSObject class]];
   IOSObjectArray *array = [IOSObjectArray arrayWithLength:10 type:elementType];
   int length = (int) [array count];
   XCTAssertEqual(length, 10, @"incorrect array size: %d", length);
@@ -42,7 +42,7 @@
 }
 
 - (void)testElementAccess {
-  IOSClass * elementType = [IOSClass classWithClass:[NSString class]];
+  IOSClass * elementType = [IOSClass classFromClass:[NSString class]];
   IOSObjectArray *array = [IOSObjectArray arrayWithLength:3 type:elementType];
   [array replaceObjectAtIndex:0 withObject:@"zero"];
   [array replaceObjectAtIndex:2 withObject:@"two"];
@@ -52,7 +52,7 @@
 }
 
 - (void)testGetObjects {
-  IOSClass * elementType = [IOSClass classWithClass:[NSString class]];
+  IOSClass * elementType = [IOSClass classFromClass:[NSString class]];
   IOSObjectArray *array = [IOSObjectArray arrayWithLength:3 type:elementType];
   [array replaceObjectAtIndex:0 withObject:@"zero"];
   [array replaceObjectAtIndex:2 withObject:@"two"];
@@ -65,7 +65,7 @@
 }
 
 - (void)testReplaceObject {
-  IOSClass * elementType = [IOSClass classWithClass:[NSString class]];
+  IOSClass * elementType = [IOSClass classFromClass:[NSString class]];
   IOSObjectArray *array = [IOSObjectArray arrayWithLength:1 type:elementType];
   NSObject *item = @"foo";
   id result = [array replaceObjectAtIndex:0 withObject:item];
@@ -75,7 +75,7 @@
 }
 
 - (void)testArrayCopy {
-  IOSClass *type = [IOSClass classWithClass:[NSNumber class]];
+  IOSClass *type = [IOSClass classFromClass:[NSNumber class]];
   IOSObjectArray *numbers = [IOSObjectArray arrayWithLength:5 type:type];
   for (int i = 0; i < 5; i++) {
     [numbers replaceObjectAtIndex:i
@@ -96,7 +96,7 @@
 }
 
 - (void)testOverlappingArrayCopy {
-  IOSClass *type = [IOSClass classWithClass:[NSNumber class]];
+  IOSClass *type = [IOSClass classFromClass:[NSNumber class]];
   IOSObjectArray *numbers = [IOSObjectArray arrayWithLength:5 type:type];
   for (int i = 0; i < 5; i++) {
     [numbers replaceObjectAtIndex:i
@@ -113,7 +113,7 @@
 }
 
 - (void)testCopy {
-  IOSClass *type = [IOSClass classWithClass:[NSNumber class]];
+  IOSClass *type = [IOSClass classFromClass:[NSNumber class]];
   IOSObjectArray *array = [IOSObjectArray arrayWithLength:10 type:type];
   for (int i = 0; i < 10; i++) {
     [array replaceObjectAtIndex:i

--- a/jre_emul/Classes/IOSPrimitiveClass.m
+++ b/jre_emul/Classes/IOSPrimitiveClass.m
@@ -85,7 +85,7 @@
 
 - (IOSObjectArray *)getDeclaredMethods {
   return [IOSObjectArray arrayWithLength:0
-      type:[IOSClass classWithClass:[JavaLangReflectMethod class]]];
+      type:[IOSClass classFromClass:[JavaLangReflectMethod class]]];
 }
 
 - (JavaLangReflectMethod *)getMethod:(NSString *)name, ... {
@@ -153,14 +153,14 @@ getConstructorWithClasses:(IOSClass *)firstClass, ... {
 
 - (id)wrapperClass {
   switch ([type_ characterAtIndex:0]) {
-    case 'B': return [IOSClass classWithClass:[JavaLangByte class]];
-    case 'C': return [IOSClass classWithClass:[JavaLangCharacter class]];
-    case 'D': return [IOSClass classWithClass:[JavaLangDouble class]];
-    case 'F': return [IOSClass classWithClass:[JavaLangFloat class]];
-    case 'I': return [IOSClass classWithClass:[JavaLangInteger class]];
-    case 'J': return [IOSClass classWithClass:[JavaLangLong class]];
-    case 'S': return [IOSClass classWithClass:[JavaLangShort class]];
-    case 'Z': return [IOSClass classWithClass:[JavaLangBoolean class]];
+    case 'B': return [IOSClass classFromClass:[JavaLangByte class]];
+    case 'C': return [IOSClass classFromClass:[JavaLangCharacter class]];
+    case 'D': return [IOSClass classFromClass:[JavaLangDouble class]];
+    case 'F': return [IOSClass classFromClass:[JavaLangFloat class]];
+    case 'I': return [IOSClass classFromClass:[JavaLangInteger class]];
+    case 'J': return [IOSClass classFromClass:[JavaLangLong class]];
+    case 'S': return [IOSClass classFromClass:[JavaLangShort class]];
+    case 'Z': return [IOSClass classFromClass:[JavaLangBoolean class]];
   }
   return nil;
 }

--- a/jre_emul/Classes/IOSProtocolClass.m
+++ b/jre_emul/Classes/IOSProtocolClass.m
@@ -150,7 +150,7 @@
   Protocol * __unsafe_unretained *interfaces = protocol_copyProtocolList(protocol_, &outCount);
   NSMutableArray *result = [NSMutableArray arrayWithCapacity:outCount];
   for (unsigned i = 0; i < outCount; i++) {
-    IOSClass *interface = [IOSClass classWithProtocol:interfaces[i]];
+    IOSClass *interface = [IOSClass classFromProtocol:interfaces[i]];
     NSString *name = [interface getName];
     // Don't include NSObject and JavaObject interfaces, since java.lang.Object is a class.
     if (![name isEqualToString:@"JavaObject"] && ![name isEqualToString:@"java.lang.Object"]) {

--- a/jre_emul/Classes/JavaLangReflectMethodTest.m
+++ b/jre_emul/Classes/JavaLangReflectMethodTest.m
@@ -44,7 +44,7 @@ static double defaultValue = 3.1416;
 
 - (void)setUp {
   object_ = [[[JavaUtilLinkedList alloc] init] autorelease];
-  class_ = [IOSClass classWithClass:[object_ class]];
+  class_ = [IOSClass classFromClass:[object_ class]];
 }
 
 - (void)testGetName {
@@ -68,7 +68,7 @@ static double defaultValue = 3.1416;
 - (void)testInvocation {
   JavaLangReflectMethod *sizeMethod = [class_ getMethod:@"size"
                                          parameterTypes:nil];
-  IOSClass *objectType = [IOSClass classWithClass:[NSObject class]];
+  IOSClass *objectType = [IOSClass classFromClass:[NSObject class]];
   IOSObjectArray *parameters = [IOSObjectArray arrayWithLength:0 type:objectType];
   id result = [sizeMethod invokeWithId:object_
                            withNSObjectArray:parameters];
@@ -81,10 +81,10 @@ static double defaultValue = 3.1416;
 static id invokeValueMethod(NSString *methodName) {
   JavaLangDouble *value =
       [[[JavaLangDouble alloc] initWithDouble:defaultValue] autorelease];
-  IOSClass *doubleClass = [IOSClass classWithClass:[value class]];
+  IOSClass *doubleClass = [IOSClass classFromClass:[value class]];
   JavaLangReflectMethod *method = [doubleClass getMethod:methodName
                                           parameterTypes:nil];
-  IOSClass *objectType = [IOSClass classWithClass:[NSObject class]];
+  IOSClass *objectType = [IOSClass classFromClass:[NSObject class]];
   IOSObjectArray *parameters = [IOSObjectArray arrayWithLength:0 type:objectType];
   return [method invokeWithId:value
                   withNSObjectArray:parameters];

--- a/jre_emul/Classes/JavaMetadata.m
+++ b/jre_emul/Classes/JavaMetadata.m
@@ -142,7 +142,7 @@ static jint countArgs(char *s) {
     return nil;
   }
   IOSObjectArray *result = [IOSObjectArray arrayWithLength:size type:
-      [IOSClass classWithProtocol:@protocol(JavaLangReflectType)]];
+      [IOSClass classFromProtocol:@protocol(JavaLangReflectType)]];
   for (int i = 0; i < size; i++) {
     IOSObjectArray_Set(result, i, JreTypeForString(data_->superclassTypeArgs[i]));
   }

--- a/jre_emul/Classes/JreEmulation.m
+++ b/jre_emul/Classes/JreEmulation.m
@@ -49,7 +49,7 @@ void JrePrintNilChkCountAtExit() {
 // is passed to a Java main method.
 FOUNDATION_EXPORT
     IOSObjectArray *JreEmulationMainArguments(int argc, const char *argv[]) {
-  IOSClass *stringType = [IOSClass classWithClass:[NSString class]];
+  IOSClass *stringType = [IOSClass classFromClass:[NSString class]];
   if (argc <= 1) {
     return [IOSObjectArray arrayWithLength:0 type:stringType];
   }

--- a/jre_emul/Classes/NSObject+JavaObject.m
+++ b/jre_emul/Classes/NSObject+JavaObject.m
@@ -53,7 +53,7 @@
 }
 
 - (IOSClass *)getClass {
-  return [IOSClass classWithClass:[self class]];
+  return [IOSClass classFromClass:[self class]];
 }
 
 - (int)compareToWithId:(id)other {

--- a/jre_emul/Classes/NSString+JavaString.m
+++ b/jre_emul/Classes/NSString+JavaString.m
@@ -1056,7 +1056,7 @@ IOSObjectArray *NSString_serialPersistentFields_;
                               [[JavaLangString_CaseInsensitiveComparator alloc] init]);
     JreStrongAssignAndConsume(&NSString_serialPersistentFields_, nil,
         [IOSObjectArray newArrayWithLength:0 type:
-            [IOSClass classWithClass:[JavaIoObjectStreamField class]]]);
+            [IOSClass classFromClass:[JavaIoObjectStreamField class]]]);
     J2OBJC_SET_INITIALIZED(NSString)
   }
 }

--- a/jre_emul/Classes/java/lang/Throwable.m
+++ b/jre_emul/Classes/java/lang/Throwable.m
@@ -228,7 +228,7 @@ void FillInStackTraceInternal(JavaLangThrowable *this) {
   @synchronized (self) {
     jint existingCount = suppressedExceptions ? suppressedExceptions->size_ : 0;
     IOSObjectArray *newArray = [IOSObjectArray newArrayWithLength:existingCount + 1
-        type:[IOSClass classWithClass:[JavaLangThrowable class]]];
+        type:[IOSClass classFromClass:[JavaLangThrowable class]]];
     for (jint i = 0; i < existingCount; i++) {
       [newArray replaceObjectAtIndex:i withObject:suppressedExceptions->buffer_[i]];
     }
@@ -243,7 +243,7 @@ void FillInStackTraceInternal(JavaLangThrowable *this) {
   return suppressedExceptions
       ? [IOSObjectArray arrayWithArray:suppressedExceptions]
       : [IOSObjectArray arrayWithLength:0
-          type:[IOSClass classWithClass:[JavaLangThrowable class]]];
+          type:[IOSClass classFromClass:[JavaLangThrowable class]]];
 }
 
 - (NSString *)description {

--- a/jre_emul/Classes/java/lang/reflect/AccessibleObject.m
+++ b/jre_emul/Classes/java/lang/reflect/AccessibleObject.m
@@ -81,7 +81,7 @@
     IOSObjectArray *noArgs = [IOSObjectArray arrayWithLength:0 type:[NSObject getClass]];
     return (IOSObjectArray *) [method invokeWithId:nil withNSObjectArray:noArgs];
   } else {
-    IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+    IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
     return [IOSObjectArray arrayWithLength:0 type:annotationType];
   }
 }
@@ -121,7 +121,7 @@ IOSClass *decodeTypeEncoding(const char *type) {
     case '@':
       return [IOSClass objectClass];
     case '#':
-      return [IOSClass classWithClass:[IOSClass class]];
+      return [IOSClass classFromClass:[IOSClass class]];
     case 'c':
       return [IOSClass byteClass];
     case 'S':

--- a/jre_emul/Classes/java/lang/reflect/ExecutableMember.m
+++ b/jre_emul/Classes/java/lang/reflect/ExecutableMember.m
@@ -112,7 +112,7 @@ static IOSClass *ResolveParameterType(const char *objcType, NSString *paramKeywo
 - (IOSObjectArray *)getParameterTypes {
   // First two slots are class and SEL.
   jint nArgs = (jint)[methodSignature_ numberOfArguments] - SKIPPED_ARGUMENTS;
-  IOSClass *classClass = [IOSClass classWithClass:[IOSClass class]];
+  IOSClass *classClass = [IOSClass classFromClass:[IOSClass class]];
   IOSObjectArray *parameters = [IOSObjectArray arrayWithLength:nArgs type:classClass];
 
   NSString *selectorStr = NSStringFromSelector(selector_);
@@ -146,7 +146,7 @@ static IOSClass *ResolveParameterType(const char *objcType, NSString *paramKeywo
 }
 
 - (IOSObjectArray *)getTypeParameters {
-  IOSClass *typeVariableType = [IOSClass classWithProtocol:@protocol(JavaLangReflectTypeVariable)];
+  IOSClass *typeVariableType = [IOSClass classFromProtocol:@protocol(JavaLangReflectTypeVariable)];
   return[IOSObjectArray arrayWithLength:0 type:typeVariableType];
 }
 
@@ -192,7 +192,7 @@ static IOSClass *ResolveParameterType(const char *objcType, NSString *paramKeywo
       return method_invoke(cls, annotationsMethod);
     }
   }
-  IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+  IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
   return [IOSObjectArray arrayWithLength:0 type:annotationType];
 }
 
@@ -206,7 +206,7 @@ static IOSClass *ResolveParameterType(const char *objcType, NSString *paramKeywo
       return method_invoke(cls, annotationsMethod);
     }
   }
-  IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+  IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
   return [IOSObjectArray arrayWithDimensions:2 lengths:(int[]){0, 0} type:annotationType];
 }
 

--- a/jre_emul/Classes/java/lang/reflect/Field.m
+++ b/jre_emul/Classes/java/lang/reflect/Field.m
@@ -331,7 +331,7 @@ static void SetWithRawValue(
       return method_invoke(cls, annotationsMethod);
     }
   }
-  IOSClass *annotationType = [IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)];
+  IOSClass *annotationType = [IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)];
   return [IOSObjectArray arrayWithLength:0 type:annotationType];
 }
 

--- a/jre_emul/Classes/javax/annotation/Resource.m
+++ b/jre_emul/Classes/javax/annotation/Resource.m
@@ -68,13 +68,13 @@
 }
 
 + (IOSClass *)typeDefault {
-  return [IOSClass classWithClass:[NSObject class]];
+  return [IOSClass classFromClass:[NSObject class]];
 }
 
 
 
 - (IOSClass *)annotationType {
-  return [IOSClass classWithProtocol:@protocol(JavaxAnnotationResource)];
+  return [IOSClass classFromProtocol:@protocol(JavaxAnnotationResource)];
 }
 
 + (IOSObjectArray *)__annotations {
@@ -86,7 +86,7 @@
       JavaLangAnnotationElementTypeEnum_get_METHOD(),
       JavaLangAnnotationElementTypeEnum_get_FIELD()
     } count:3 type:[[NSObject class] getClass]]] autorelease]
-  } count:2 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];
+  } count:2 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];
 }
 
 + (const J2ObjcClassInfo *)__metadata {
@@ -117,7 +117,7 @@ JavaxAnnotationResource_AuthenticationTypeEnum *
 
 FOUNDATION_EXPORT IOSObjectArray *JavaxAnnotationResource_AuthenticationTypeEnum_values() {
   IOSClass *enumType =
-      [IOSClass classWithClass:[JavaxAnnotationResource_AuthenticationTypeEnum class]];
+      [IOSClass classFromClass:[JavaxAnnotationResource_AuthenticationTypeEnum class]];
   return [IOSObjectArray arrayWithObjects:JavaxAnnotationResource_AuthenticationTypeEnum_values_
                                     count:2
                                      type:enumType];

--- a/jre_emul/android/libcore/luni/src/main/java/java/lang/reflect/Proxy.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/lang/reflect/Proxy.java
@@ -294,7 +294,7 @@ public class Proxy implements Serializable {
       Method constructor = class_getInstanceMethod([JavaLangReflectProxy class], sel);
       class_addMethod(proxyClass, sel, method_getImplementation(constructor),
           method_getTypeEncoding(constructor));
-      return [IOSClass classWithClass:proxyClass];
+      return [IOSClass classFromClass:proxyClass];
     ]-*/;
 
     /*-[
@@ -331,7 +331,7 @@ public class Proxy implements Serializable {
         struct objc_method_description methodDescription =
             protocol_getMethodDescription(protocol, selector, YES, YES);
         if (methodDescription.name && sel_isEqual(selector, methodDescription.name)) {
-          IOSClass *iosProtocol = [IOSClass classWithProtocol:protocol];
+          IOSClass *iosProtocol = [IOSClass classFromProtocol:protocol];
           JavaLangReflectMethod *method =
               [iosProtocol findMethodWithTranslatedName:NSStringFromSelector(selector)];
           IOSObjectArray *paramTypes = [method getParameterTypes];

--- a/jre_emul/android/libcore/luni/src/main/java/java/util/TimeZone.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/TimeZone.java
@@ -115,7 +115,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
     public static synchronized native String[] getAvailableIDs() /*-[
       NSArray *timeZones = [NSTimeZone knownTimeZoneNames];
       return [IOSObjectArray arrayWithNSArray:timeZones
-                                         type:[IOSClass classWithClass:[NSString class]]];
+                                         type:[IOSClass classFromClass:[NSString class]]];
     ]-*/;
 
     /**
@@ -136,7 +136,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
         }
       }
       return [IOSObjectArray arrayWithNSArray:results
-                                         type:[IOSClass classWithClass:[NSString class]]];
+                                         type:[IOSClass classFromClass:[NSString class]]];
     ]-*/;
 
     /**

--- a/testing/junit-ext/src/java/com/google/j2objc/testing/JUnitTestRunner.java
+++ b/testing/junit-ext/src/java/com/google/j2objc/testing/JUnitTestRunner.java
@@ -214,7 +214,7 @@ public class JUnitTestRunner {
     for (int i = 0; i < classCount; i++) {
       Class cls = classes[i];
       if (IsNSObjectClass(cls)) {
-        IOSClass *javaClass = [IOSClass classWithClass:cls];
+        IOSClass *javaClass = [IOSClass classFromClass:cls];
         if ([self isJUnitTestClassWithIOSClass:javaClass]) {
           [result addWithId:javaClass];
         }

--- a/testing/mockito/src/main/java/org/mockito/internal/creation/ios/IosMockMaker.java
+++ b/testing/mockito/src/main/java/org/mockito/internal/creation/ios/IosMockMaker.java
@@ -142,7 +142,7 @@ public final class IosMockMaker implements MockMaker {
       class_addProtocol(proxyClass, intrface.objcProtocol);
     }
     objc_registerClassPair(proxyClass);
-    return [IOSClass classWithClass:proxyClass];
+    return [IOSClass classFromClass:proxyClass];
   ]-*/;
 
   static class ClassProxy {
@@ -159,7 +159,7 @@ public final class IosMockMaker implements MockMaker {
     /*-[
     static IOSClass* getMethodDescription(Class cls, SEL aSelector,
         struct objc_method_description *md) {
-      IOSClass *mockClass = [IOSClass classWithClass:cls];
+      IOSClass *mockClass = [IOSClass classFromClass:cls];
       IOSClass *mockedClass =
           [OrgMockitoInternalCreationIosIosMockMaker_proxyCache_ getWithId:mockClass];
 
@@ -202,7 +202,7 @@ public final class IosMockMaker implements MockMaker {
         if (methodDescription.name && sel_isEqual(aSelector, methodDescription.name)) {
           memcpy(md, &methodDescription, sizeof(struct objc_method_description));
           free(interfaces);
-          return [IOSClass classWithProtocol:interfaces[i]];
+          return [IOSClass classFromProtocol:interfaces[i]];
         }
       }
       free(interfaces);

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/ObjectiveCImplementationGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/ObjectiveCImplementationGenerator.java
@@ -240,7 +240,7 @@ public class ObjectiveCImplementationGenerator extends ObjectiveCSourceFileGener
     }
     printStaticVars(node);
     println("\n- (IOSClass *)annotationType {");
-    printf("  return [IOSClass classWithProtocol:@protocol(%s)];\n", typeName);
+    printf("  return [IOSClass classFromProtocol:@protocol(%s)];\n", typeName);
     println("}");
     printMethods(methods);
     if (TranslationUtil.needsReflection(node)) {
@@ -702,14 +702,14 @@ public class ObjectiveCImplementationGenerator extends ObjectiveCSourceFileGener
         if (runtimeAnnotations.size() > 0) {
           print("[IOSObjectArray arrayWithObjects:(id[]) { ");
           printAnnotations(runtimeAnnotations);
-          printf(" } count:%d type:[IOSClass classWithProtocol:"
+          printf(" } count:%d type:[IOSClass classFromProtocol:"
               + "@protocol(JavaLangAnnotationAnnotation)]]", runtimeAnnotations.size());
         } else {
           print("[IOSObjectArray arrayWithLength:0 "
-              + "type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]]");
+              + "type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]]");
         }
       }
-      printf(" } count:%d type:[IOSClass classWithProtocol:"
+      printf(" } count:%d type:[IOSClass classFromProtocol:"
           + "@protocol(JavaLangAnnotationAnnotation)]];\n}\n", params.size());
     }
   }
@@ -731,7 +731,7 @@ public class ObjectiveCImplementationGenerator extends ObjectiveCSourceFileGener
     print("  return [IOSObjectArray arrayWithObjects:(id[]) { ");
     printAnnotations(runtimeAnnotations);
     printf(" } count:%d type:[IOSClass "
-        + "classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];\n}\n",
+        + "classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];\n}\n",
         runtimeAnnotations.size());
   }
 
@@ -784,7 +784,7 @@ public class ObjectiveCImplementationGenerator extends ObjectiveCSourceFileGener
     } else if (value instanceof ITypeBinding) {
       ITypeBinding type = (ITypeBinding) value;
       if (type.isInterface()) {
-        printf("[IOSClass classWithProtocol:@protocol(%s)]", NameTable.getFullName(type));
+        printf("[IOSClass classFromProtocol:@protocol(%s)]", NameTable.getFullName(type));
       } else {
         printf("[[%s class] getClass]", NameTable.getFullName(type));
       }

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -1227,11 +1227,11 @@ public class StatementGenerator extends TreeVisitor {
     if (type.isPrimitive()) {
       buffer.append(String.format("[IOSClass %sClass]", type.getName()));
     } else if (type.isInterface()) {
-      buffer.append("[IOSClass classWithProtocol:@protocol(");
+      buffer.append("[IOSClass classFromProtocol:@protocol(");
       buffer.append(NameTable.getFullName(type));
       buffer.append(")]");
     } else {
-      buffer.append("[IOSClass classWithClass:[");
+      buffer.append("[IOSClass classFromClass:[");
       buffer.append(NameTable.getFullName(type));
       buffer.append(" class]]");
     }

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
@@ -136,7 +136,7 @@ public class EnumRewriter extends TreeVisitor {
     sb.append(String.format(
         "FOUNDATION_EXPORT IOSObjectArray *%s_values() {\n"
         + "  return [IOSObjectArray arrayWithObjects:%s_values_ count:%s type:"
-        + "[IOSClass classWithClass:[%s class]]];\n"
+        + "[IOSClass classFromClass:[%s class]]];\n"
         + "}\n"
         + "+ (IOSObjectArray *)values {\n"
         + "  return %s_values();\n"

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/ArrayCreationTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/ArrayCreationTest.java
@@ -90,7 +90,7 @@ public class ArrayCreationTest extends GenerationTest {
     assertEquals(1, stmts.size());
     String result = generateStatement(stmts.get(0));
     assertEquals("IOSObjectArray *foo = [IOSObjectArray "
-        + "arrayWithLength:3 type:[IOSClass classWithClass:[JavaLangInteger class]]];",
+        + "arrayWithLength:3 type:[IOSClass classFromClass:[JavaLangInteger class]]];",
         result);
   }
 

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCImplementationGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCImplementationGeneratorTest.java
@@ -325,7 +325,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
 
     assertTranslatedLines(translation,
         "- (IOSClass *)annotationType {",
-        "return [IOSClass classWithProtocol:@protocol(FooCompatible)];");
+        "return [IOSClass classFromProtocol:@protocol(FooCompatible)];");
   }
 
   public void testMethodsWithTypeParameters() throws IOException {
@@ -493,7 +493,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "Test", "Test.m");
     assertTranslation(translation, "void Test_foo() {\n"
         + "  Test_init();\n"
-        + "  @synchronized([IOSClass classWithClass:[Test class]]) {");
+        + "  @synchronized([IOSClass classFromClass:[Test class]]) {");
   }
 
   // Verify that an interface that has a generated implementation file and an Object method
@@ -537,7 +537,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "+ (IOSObjectArray *)__annotations_foo {",
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[OrgJunitAfter alloc] init] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testMethodAnnotationWithParameter() throws IOException {
@@ -549,7 +549,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "+ (IOSObjectArray *)__annotations_fooWithInt_ {",
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[OrgJunitAfter alloc] init] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testConstructorAnnotationNoParameters() throws IOException {
@@ -560,7 +560,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "+ (IOSObjectArray *)__annotations_Test {",
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[JavaLangDeprecated alloc] init] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testConstructorAnnotationWithParameter() throws IOException {
@@ -571,7 +571,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "+ (IOSObjectArray *)__annotations_TestWithInt_ {",
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[JavaLangDeprecated alloc] init] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testTypeAnnotationDefaultParameter() throws IOException {
@@ -583,7 +583,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "+ (IOSObjectArray *)__annotations {",
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[OrgJunitIgnore alloc] initWithValue:@\"\"] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testTypeAnnotationWithParameter() throws IOException {
@@ -596,7 +596,7 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         "return [IOSObjectArray arrayWithObjects:(id[]) "
         + "{ [[[OrgJunitIgnore alloc] initWithValue:"
         + "@\"some \\\"escaped\\n comment\"] autorelease] } "
-        + "count:1 type:[IOSClass classWithProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
+        + "count:1 type:[IOSClass classFromProtocol:@protocol(JavaLangAnnotationAnnotation)]];");
   }
 
   public void testFreeFormNativeCode() throws IOException {
@@ -777,6 +777,6 @@ public class ObjectiveCImplementationGeneratorTest extends GenerationTest {
         + " @interface Foo { Class<?> value(); }", "Foo.java");
     String translation = translateSourceFile(
         "@Foo(CharSequence.class) class Test {}", "Test", "Test.m");
-    assertTranslation(translation, "[IOSClass classWithProtocol:@protocol(JavaLangCharSequence)]");
+    assertTranslation(translation, "[IOSClass classFromProtocol:@protocol(JavaLangCharSequence)]");
   }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
@@ -332,7 +332,7 @@ public class StatementGeneratorTest extends GenerationTest {
     assertTranslation(translation, "[self fooWithNSObjectArray:");
     assertTranslation(translation,
         "[IOSObjectArray arrayWithObjects:(id[]){ nil, nil } count:2 "
-        + "type:[IOSClass classWithClass:[NSObject class]]]");
+        + "type:[IOSClass classFromClass:[NSObject class]]]");
     assertTranslation(translation, "[self barWithNSString:");
     assertTranslation(translation, "withNSObjectArray:");
   }
@@ -345,7 +345,7 @@ public class StatementGeneratorTest extends GenerationTest {
     assertTranslation(translation,
         "[self fooWithNSObjectArray:"
         + "[IOSObjectArray arrayWithObjects:(id[]){ JavaLangInteger_valueOfWithInt_(1) } count:1 "
-        + "type:[IOSClass classWithClass:[NSObject class]]]];");
+        + "type:[IOSClass classFromClass:[NSObject class]]]];");
   }
 
   public void testVarargsMethodInvocationPrimitiveArgs() throws IOException {
@@ -640,7 +640,7 @@ public class StatementGeneratorTest extends GenerationTest {
     result = generateStatement(stmts.get(1));
     assertEquals("IOSClass *mySuperClass = [myClass getSuperclass];", result);
     result = generateStatement(stmts.get(2));
-    assertEquals("IOSClass *enumClass = [IOSClass classWithClass:[JavaLangEnum class]];", result);
+    assertEquals("IOSClass *enumClass = [IOSClass classFromClass:[JavaLangEnum class]];", result);
   }
 
   public void testCastInConstructorChain() throws IOException {
@@ -828,7 +828,7 @@ public class StatementGeneratorTest extends GenerationTest {
     assertEquals(2, stmts.size());
     String result = generateStatement(stmts.get(1));
     assertEquals(
-        "if ([[IOSObjectArray iosClassWithType:[IOSClass classWithClass:[NSString class]]] "
+        "if ([[IOSObjectArray iosClassWithType:[IOSClass classFromClass:[NSString class]]] "
         + "isInstance:args]) {\n}", result);
   }
 
@@ -838,7 +838,7 @@ public class StatementGeneratorTest extends GenerationTest {
     assertEquals(2, stmts.size());
     String result = generateStatement(stmts.get(1));
     assertEquals(
-        "if ([[IOSObjectArray iosClassWithType:[IOSClass classWithProtocol:"
+        "if ([[IOSObjectArray iosClassWithType:[IOSClass classFromProtocol:"
         + "@protocol(JavaLangReadable)]] isInstance:args]) {\n}", result);
   }
 
@@ -857,7 +857,7 @@ public class StatementGeneratorTest extends GenerationTest {
     String result = generateStatement(stmts.get(0));
     assertEquals("IOSObjectArray *a = [IOSObjectArray "
         + "arrayWithObjects:(id[]){ @\"one\", @\"two\", @\"three\" } "
-        + "count:3 type:[IOSClass classWithClass:[NSString class]]];", result);
+        + "count:3 type:[IOSClass classFromClass:[NSString class]]];", result);
 
     source = "Comparable[] a = { \"one\", \"two\", \"three\" };";
     stmts = translateStatements(source);
@@ -865,7 +865,7 @@ public class StatementGeneratorTest extends GenerationTest {
     result = generateStatement(stmts.get(0));
     assertEquals("IOSObjectArray *a = [IOSObjectArray "
         + "arrayWithObjects:(id[]){ @\"one\", @\"two\", @\"three\" } "
-        + "count:3 type:[IOSClass classWithProtocol:@protocol(JavaLangComparable)]];", result);
+        + "count:3 type:[IOSClass classFromProtocol:@protocol(JavaLangComparable)]];", result);
   }
 
   public void testArrayPlusAssign() throws IOException {
@@ -950,11 +950,11 @@ public class StatementGeneratorTest extends GenerationTest {
     assertTranslation(translation,
         "IOSObjectArray *a = [IOSObjectArray arrayWithObjects:(id[]){ nil, "
         + "[IOSObjectArray arrayWithObjects:(id[]){ i_, j_ } count:2 "
-        + "type:[IOSClass classWithClass:[JavaLangInteger class]]], "
+        + "type:[IOSClass classFromClass:[JavaLangInteger class]]], "
         + "[IOSObjectArray arrayWithObjects:(id[]){ j_, i_ } count:2 "
-        + "type:[IOSClass classWithClass:[JavaLangInteger class]]] } count:3 "
+        + "type:[IOSClass classFromClass:[JavaLangInteger class]]] } count:3 "
         + "type:[IOSObjectArray iosClassWithType:"
-        + "[IOSClass classWithClass:[JavaLangInteger class]]]];");
+        + "[IOSClass classFromClass:[JavaLangInteger class]]]];");
   }
 
   public void testVarargsMethodInvocationZeroLengthArray() throws IOException {
@@ -971,15 +971,15 @@ public class StatementGeneratorTest extends GenerationTest {
     // Should be equivalent to foo(new Object[0]).
     assertTranslation(translation,
         "[self fooWithNSObjectArray:[IOSObjectArray "
-        + "arrayWithLength:0 type:[IOSClass classWithClass:[NSObject class]]]]");
+        + "arrayWithLength:0 type:[IOSClass classFromClass:[NSObject class]]]]");
 
     // Should be equivalent to bar(new Object[] { new Object[0] }).
     assertTranslation(translation,
         "[self barWithNSObjectArray2:[IOSObjectArray arrayWithObjects:"
         + "(id[]){ [IOSObjectArray arrayWithLength:0 type:"
-        + "[IOSClass classWithClass:[NSObject class]]] } count:1 "
+        + "[IOSClass classFromClass:[NSObject class]]] } count:1 "
         + "type:[IOSObjectArray iosClassWithType:"
-        + "[IOSClass classWithClass:[NSObject class]]]]];");
+        + "[IOSClass classFromClass:[NSObject class]]]]];");
   }
 
   public void testVarargsIOSMethodInvocation() throws IOException {
@@ -993,21 +993,21 @@ public class StatementGeneratorTest extends GenerationTest {
         + "  Constructor c4 = Test.class.getConstructor(types); }}",
         "Test", "Test.m");
     assertTranslation(translation,
-        "c1 = [[IOSClass classWithClass:[Test class]] getConstructor:"
+        "c1 = [[IOSClass classFromClass:[Test class]] getConstructor:"
         + "[IOSObjectArray arrayWithLength:0 type:"
-        + "[IOSClass classWithClass:[IOSClass class]]]];");
+        + "[IOSClass classFromClass:[IOSClass class]]]];");
     assertTranslation(translation,
-        "c2 = [[IOSClass classWithClass:[Test class]] getConstructor:"
-        + "[IOSObjectArray arrayWithObjects:(id[]){ [IOSClass classWithClass:[NSString class]] } "
-        + "count:1 type:[IOSClass classWithClass:[IOSClass class]]]];");
+        "c2 = [[IOSClass classFromClass:[Test class]] getConstructor:"
+        + "[IOSObjectArray arrayWithObjects:(id[]){ [IOSClass classFromClass:[NSString class]] } "
+        + "count:1 type:[IOSClass classFromClass:[IOSClass class]]]];");
     assertTranslation(translation,
-        "c3 = [[IOSClass classWithClass:[Test class]] getConstructor:"
-        + "[IOSObjectArray arrayWithObjects:(id[]){ [IOSClass classWithClass:[NSString class]], "
-        + "JavaLangByte_get_TYPE_() } count:2 type:[IOSClass classWithClass:[IOSClass class]]]];");
+        "c3 = [[IOSClass classFromClass:[Test class]] getConstructor:"
+        + "[IOSObjectArray arrayWithObjects:(id[]){ [IOSClass classFromClass:[NSString class]], "
+        + "JavaLangByte_get_TYPE_() } count:2 type:[IOSClass classFromClass:[IOSClass class]]]];");
 
     // Array contents should be expanded.
     assertTranslation(translation,
-        "c4 = [[IOSClass classWithClass:[Test class]] getConstructor:types];");
+        "c4 = [[IOSClass classFromClass:[Test class]] getConstructor:types];");
   }
 
   public void testGetVarargsWithLeadingParameter() throws IOException {
@@ -1018,8 +1018,8 @@ public class StatementGeneratorTest extends GenerationTest {
         "Test", "Test.m");
     assertTranslation(translation,
         "[[self getClass] getMethod:@\"equals\" parameterTypes:[IOSObjectArray "
-        + "arrayWithObjects:(id[]){ [IOSClass classWithClass:[NSObject class]] } count:1 "
-        + "type:[IOSClass classWithClass:[IOSClass class]]]];");
+        + "arrayWithObjects:(id[]){ [IOSClass classFromClass:[NSObject class]] } count:1 "
+        + "type:[IOSClass classFromClass:[IOSClass class]]]];");
   }
 
   public void testGetVarargsWithLeadingParameterNoArgs() throws IOException {
@@ -1030,7 +1030,7 @@ public class StatementGeneratorTest extends GenerationTest {
         "Test", "Test.m");
     assertTranslation(translation,
         "[[self getClass] getMethod:@\"hashCode\" parameterTypes:[IOSObjectArray "
-        + "arrayWithLength:0 type:[IOSClass classWithClass:[IOSClass class]]]];");
+        + "arrayWithLength:0 type:[IOSClass classFromClass:[IOSClass class]]]];");
   }
 
   public void testTypeVariableWithBoundCast() throws IOException {
@@ -1364,7 +1364,7 @@ public class StatementGeneratorTest extends GenerationTest {
         "[self checkWithBoolean:YES withNSString:@\"%d-%d\" "
         + "withNSObjectArray:[IOSObjectArray arrayWithObjects:(id[]){ "
         + "JavaLangInteger_valueOfWithInt_(i), JavaLangInteger_valueOfWithInt_(j) } count:2 "
-        + "type:[IOSClass classWithClass:[NSObject class]]]];");
+        + "type:[IOSClass classFromClass:[NSObject class]]]];");
   }
 
   // Verify that a string == comparison is converted to compare invocation.
@@ -1581,7 +1581,7 @@ public class StatementGeneratorTest extends GenerationTest {
         + "  Deprecated deprecated() { "
         + "    return Test.class.getAnnotation(Deprecated.class); }}",
         "Test", "Test.m");
-    assertTranslation(translation, "[IOSClass classWithProtocol:@protocol(JavaLangDeprecated)]]");
+    assertTranslation(translation, "[IOSClass classFromProtocol:@protocol(JavaLangDeprecated)]]");
   }
 
   public void testEnumThisCallWithNoArguments() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/AnonymousClassConverterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/AnonymousClassConverterTest.java
@@ -116,7 +116,7 @@ public class AnonymousClassConverterTest extends GenerationTest {
         "+ (void)initialize {",
         "if (self == [Test class]) {",
         "JreStrongAssignAndConsume(&Test_t_, nil, [[Test_$1 alloc] "
-            + "initWithIOSClass:[IOSClass classWithClass:[Test class]]]);");
+            + "initWithIOSClass:[IOSClass classFromClass:[Test class]]]);");
   }
 
   public void testFinalParameter() throws IOException {
@@ -502,6 +502,6 @@ public class AnonymousClassConverterTest extends GenerationTest {
     assertTranslation(translation,
         "[super initWithNSString:arg$0 withNSObjectArray:"
         + "[IOSObjectArray arrayWithObjects:(id[]){ arg$1, arg$2 } count:2 "
-        + "type:[IOSClass classWithClass:[NSObject class]]]]");
+        + "type:[IOSClass classFromClass:[NSObject class]]]]");
   }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
@@ -41,7 +41,7 @@ public class AutoboxerTest extends GenerationTest {
         + "withInt:i withJavaLangIntegerArray:"
         + "[IOSObjectArray arrayWithObjects:(id[]){ JavaLangInteger_valueOfWithInt_(1), "
         + "JavaLangInteger_valueOfWithInt_(2) } count:2 type:"
-        + "[IOSClass classWithClass:[JavaLangInteger class]]]];");
+        + "[IOSClass classFromClass:[JavaLangInteger class]]]];");
   }
 
   public void testUnboxReturn() throws IOException {
@@ -227,7 +227,7 @@ public class AutoboxerTest extends GenerationTest {
         "Test", "Test.m");
     assertTranslation(translation,
         "[IOSObjectArray newArrayWithObjects:(id[]){ i_, j_, k_ } count:3 "
-        + "type:[IOSClass classWithClass:[JavaLangInteger class]]]");
+        + "type:[IOSClass classFromClass:[JavaLangInteger class]]]");
   }
 
   public void testArrayInitializerBoxed() throws IOException {
@@ -240,7 +240,7 @@ public class AutoboxerTest extends GenerationTest {
     assertTranslation(translation,
         "[IOSObjectArray arrayWithObjects:(id[]){ JavaLangInteger_valueOfWithInt_(1), "
         + "JavaLangInteger_valueOfWithInt_(2), i_ } count:3 "
-        + "type:[IOSClass classWithClass:[JavaLangInteger class]]]");
+        + "type:[IOSClass classFromClass:[JavaLangInteger class]]]");
   }
 
   public void testArrayInitializerUnboxed() throws IOException {
@@ -265,7 +265,7 @@ public class AutoboxerTest extends GenerationTest {
     assertTranslation(translation,
         "[IOSObjectArray newArrayWithObjects:(id[]){ JavaLangInteger_valueOfWithInt_(1), "
         + "JavaLangInteger_valueOfWithInt_(2), i_ } count:3 "
-        + "type:[IOSClass classWithClass:[JavaLangInteger class]]]");
+        + "type:[IOSClass classFromClass:[JavaLangInteger class]]]");
   }
 
   public void testFieldArrayInitializerUnboxed() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
@@ -310,7 +310,7 @@ public class FunctionizerTest extends GenerationTest {
         "class A { void test() { str(); } "
         + "  private static synchronized String str() { return \"abc\"; }}",
         "A", "A.m");
-    assertTranslation(translation, "@synchronized([IOSClass classWithClass:[A class]])");
+    assertTranslation(translation, "@synchronized([IOSClass classFromClass:[A class]])");
     assertOccurrences(translation, "@synchronized", 1);
     translation = translateSourceFile(
         "class A { void test() { str(); } "
@@ -321,7 +321,7 @@ public class FunctionizerTest extends GenerationTest {
         "class A { void test() { str(); } "
         + "  private static String str() { synchronized(A.class) { return \"abc\"; }}}",
         "A", "A.m");
-    assertTranslation(translation, "@synchronized([IOSClass classWithClass:[A class]])");
+    assertTranslation(translation, "@synchronized([IOSClass classFromClass:[A class]])");
   }
 
   public void testSetter() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/GwtConverterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/GwtConverterTest.java
@@ -59,7 +59,7 @@ public class GwtConverterTest extends GenerationTest {
         + "  String FOO = foo();"  // Regression requires subsequent non-mapped method invocation.
         + "  static String foo() { return \"foo\"; } }", "Test", "Test.m");
     assertTranslation(translation, "Test_set_INSTANCE_(self, "
-        + "[[IOSClass classWithClass:[Test class]] newInstance]);");
+        + "[[IOSClass classFromClass:[Test class]] newInstance]);");
   }
 
   public void testGwtIsScript() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/InitializationNormalizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/InitializationNormalizerTest.java
@@ -89,7 +89,7 @@ public class InitializationNormalizerTest extends GenerationTest {
     assertTranslation(translation,
         "[IOSObjectArray newArrayWithObjects:(id[]){ [[[Distance_SimplexVertex alloc] "
         + "initWithDistance:outer$] autorelease] } "
-        + "count:1 type:[IOSClass classWithClass:[Distance_SimplexVertex class]]]");
+        + "count:1 type:[IOSClass classFromClass:[Distance_SimplexVertex class]]]");
   }
 
   public void testStaticVarInitialization() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/InnerClassExtractorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/InnerClassExtractorTest.java
@@ -652,9 +652,9 @@ public class InnerClassExtractorTest extends GenerationTest {
         + "}";
     String translation = translateSourceFile(source, "Outer", "Outer.m");
     assertTranslation(translation, "[IOSObjectArray arrayWithObjects:(id[]){ "
-        + "@\"1\", @\"2\", @\"3\" } count:3 type:[IOSClass classWithClass:[NSString class]]]");
+        + "@\"1\", @\"2\", @\"3\" } count:3 type:[IOSClass classFromClass:[NSString class]]]");
     assertTranslation(translation, "[IOSObjectArray arrayWithObjects:(id[]){ "
-        + "@\"4\", @\"5\", @\"6\" } count:3 type:[IOSClass classWithClass:[NSString class]]]");
+        + "@\"4\", @\"5\", @\"6\" } count:3 type:[IOSClass classFromClass:[NSString class]]]");
   }
 
   public void testInnerClassVarargsConstructor() throws IOException {


### PR DESCRIPTION
...romClass and classFromProtocol.

Swift maps constructors out of class methods that follow a factory naming scheme. This becomes a problem since "WithClass" maps to "class" (and "protocol") which is a reserved word.

classWithClass and classWithProtocol have deprecated messages to maintain backwards compatiblity.

Fixes #468.