### PR TITLE
Update j2objcc.sh

### DIFF
--- a/scripts/j2objcc.sh
+++ b/scripts/j2objcc.sh
@@ -57,4 +57,4 @@ for arg; do
   esac
 done
 
-xcrun clang $* -I ${INCLUDE_PATH} ${CC_FLAGS} ${OBJC} ${LINK_FLAGS}
+xcrun clang "$@" -I ${INCLUDE_PATH} ${CC_FLAGS} ${OBJC} ${LINK_FLAGS}


### PR DESCRIPTION
This solves problems where source files have spaces in their paths.  Quoting the source files into j2objcc wouldn't fix the issue because of the way $* expands.

According to bash documentation:
```
$*	Expands to the positional parameters, starting from one. When the expansion occurs within double quotes, it expands to a single word with the value of each parameter separated by the first character of the IFS special variable.
$@	Expands to the positional parameters, starting from one. When the expansion occurs within double quotes, each parameter expands to a separate word.
```
This fixes the issue where passing in args with spaces:

`j2objcc "-I/full/path with/a/space" -o "/full/path with/a/space/target" - ObjC -ljunit "/full/path with/a/space/to/source_file.m"`

 would result in clang being invoked as such:

`xcrun clang '-Ifull/path' 'with/a/space' -o '/full/path' 'with/a/space/target' -ObjC -ljunit '/full/path' 'with/a/space/to/source_file.m'`