### PR TITLE
JreStrcat NsNull

### DIFF
--- a/jre_emul/Classes/JreEmulation.m
+++ b/jre_emul/Classes/JreEmulation.m
@@ -120,7 +120,8 @@ FOUNDATION_EXPORT NSString *JreStrcat(const char *pTypes, ...) {
       case '$':
         {
           NSString *str = va_arg(va, NSString *);
-          capacity += str ? CFStringGetLength((CFStringRef)str) : 4;
+          capacity += (str && [str isKindOfClass:[NSString class]]) ? CFStringGetLength((CFStringRef)str) : 4;
+          //there is a problem when the str as String is null in Java, it has NSNull class instead of being nil
         }
         break;
       case '@':


### PR DESCRIPTION
JreStrcat: There is a problem when the str as String is null in Java, it has NSNull class instead of being nil.
Try to use toString() method in your custom java object with any null field and then display it in ObjC.