### PR TITLE
Fix pre/postincrement of parenthesized array access (fixes #558)

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/ArrayRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/ArrayRewriter.java
@@ -25,6 +25,7 @@ import com.google.devtools.j2objc.ast.FunctionInvocation;
 import com.google.devtools.j2objc.ast.InstanceofExpression;
 import com.google.devtools.j2objc.ast.MethodInvocation;
 import com.google.devtools.j2objc.ast.NumberLiteral;
+import com.google.devtools.j2objc.ast.ParenthesizedExpression;
 import com.google.devtools.j2objc.ast.PostfixExpression;
 import com.google.devtools.j2objc.ast.PrefixExpression;
 import com.google.devtools.j2objc.ast.QualifiedName;
@@ -237,6 +238,11 @@ public class ArrayRewriter extends TreeVisitor {
 
   private static boolean needsAssignableAccess(ArrayAccess node) {
     TreeNode parent = node.getParent();
+
+    while (parent instanceof ParenthesizedExpression) {
+        parent = parent.getParent();
+    }
+
     if (parent instanceof PostfixExpression) {
       PostfixExpression.Operator op = ((PostfixExpression) parent).getOperator();
       if (op == PostfixExpression.Operator.INCREMENT

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/ArrayRewriterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/ArrayRewriterTest.java
@@ -17,8 +17,10 @@
 package com.google.devtools.j2objc.translate;
 
 import com.google.devtools.j2objc.GenerationTest;
+import com.google.devtools.j2objc.ast.Statement;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Unit tests for {@link ArrayRewriter} class.
@@ -39,5 +41,17 @@ public class ArrayRewriterTest extends GenerationTest {
         "IOSObjectArray_SetAndConsume(nil_chk(o), 0, new_NSObject_init());");
     assertTranslation(translation,
         "IOSObjectArray_SetAndConsume(o, 0, [IOSIntArray newArrayWithLength:1]);");
+  }
+
+  public void testPreAndPostincrementOfArrayAccess() throws IOException {
+    String source = "int x[] = { 0 }; ++x[0]; x[0]++; ++(x[0]); (x[0])++; ++((x[0])); ((x[0]))++;";
+    List<Statement> stmts = translateStatements(source);
+    assertEquals(7, stmts.size());
+    assertEquals("++(*IOSIntArray_GetRef(x, 0));", generateStatement(stmts.get(1)));
+    assertEquals("(*IOSIntArray_GetRef(x, 0))++;", generateStatement(stmts.get(2)));
+    assertEquals("++(*IOSIntArray_GetRef(x, 0));", generateStatement(stmts.get(3)));
+    assertEquals("(*IOSIntArray_GetRef(x, 0))++;", generateStatement(stmts.get(4)));
+    assertEquals("++((*IOSIntArray_GetRef(x, 0)));", generateStatement(stmts.get(5)));
+    assertEquals("((*IOSIntArray_GetRef(x, 0)))++;", generateStatement(stmts.get(6)));
   }
 }


### PR DESCRIPTION
This fixes #558, that pre-/postincrement expressions containing parenthesized array accesses like `(x[0])` are mistranslated. Parenthesized expressions are now "unwrapped" first in `ArrayRewriter.needsAssignableAccess` so that the outermost prefix or postfix expression can be considered with the actual array access expression. Test cases are also added to `ArrayRewriterTest`.

One thing I noticed is that, after this fix, these two expressions will have the same translated code:

```java
x[0]++;     // (*IOSIntArray_GetRef(x, 0))++;
(x[0])++;   // (*IOSIntArray_GetRef(x, 0))++;
```

But:

```java
((x[0]))++; // ((*IOSIntArray_GetRef(x, 0)))++;
```

And this is because `ComplexExpressionExtractor` [parenthesizes an expression](https://github.com/google/j2objc/blob/f72b840c21ecf3ef8e09c36d370ba743acf77b22/translator/src/main/java/com/google/devtools/j2objc/translate/ComplexExpressionExtractor.java#L159) if its parent is a pre-/postfix expression, but does nothing if it is already a `ParenthesizedExpression`.

