### PR TITLE
Use Class.isAssignableFrom to implement Class.asSubclass (fixes #563)

### DIFF
--- a/jre_emul/Classes/IOSClass.m
+++ b/jre_emul/Classes/IOSClass.m
@@ -375,7 +375,11 @@ NSString *IOSClass_GetTranslatedMethodName(IOSClass *cls, NSString *name,
 }
 
 - (IOSClass *)asSubclass:(IOSClass *)cls {
-  @throw AUTORELEASE([[JavaLangClassCastException alloc] init]);
+  if ([cls isAssignableFrom:self]) {
+    return self;
+  }
+
+  @throw AUTORELEASE([[JavaLangClassCastException alloc] initWithNSString:[self description]]);
 }
 
 - (NSString *)description {

--- a/jre_emul/Classes/IOSConcreteClass.m
+++ b/jre_emul/Classes/IOSConcreteClass.m
@@ -81,14 +81,6 @@
   return class_ == [NSObject class] ? ![cls isPrimitive] : [cls.objcClass isSubclassOfClass:class_];
 }
 
-- (IOSClass *)asSubclass:(IOSClass *)cls {
-  Class otherClass = cls.objcClass;
-  if (otherClass == nil || ![class_ isSubclassOfClass:otherClass]) {
-    @throw AUTORELEASE([[JavaLangClassCastException alloc] init]);
-  }
-  return self;
-}
-
 - (BOOL)isEnum {
   JavaClassMetadata *metadata = [self getMetadata];
   if (metadata) {

--- a/jre_emul/Tests/com/google/j2objc/ClassTest.java
+++ b/jre_emul/Tests/com/google/j2objc/ClassTest.java
@@ -327,24 +327,24 @@ public class ClassTest extends TestCase {
 
   public void testAsSubclassCalls() throws Exception {
     assertTrue(canCallAsSubclass(Integer.class, Object.class));
-    assertTrue(!canCallAsSubclass(Long.class, Integer.class));
+    assertFalse(canCallAsSubclass(Long.class, Integer.class));
     assertTrue(canCallAsSubclass(Integer[].class, Object[].class));
     assertTrue(canCallAsSubclass(Integer[].class, Object.class));
-    assertTrue(!canCallAsSubclass(int.class, Object.class));
-    assertTrue(!canCallAsSubclass(int.class, long.class));
+    assertFalse(canCallAsSubclass(int.class, Object.class));
+    assertFalse(canCallAsSubclass(int.class, long.class));
     assertTrue(canCallAsSubclass(int[].class, Object.class));
-    assertTrue(!canCallAsSubclass(int[].class, Object[].class));
+    assertFalse(canCallAsSubclass(int[].class, Object[].class));
 
     assertTrue(canCallAsSubclass(InterfaceP.class, Object.class));
-    assertTrue(!canCallAsSubclass(InterfaceP.class, InterfaceQ.class));
+    assertFalse(canCallAsSubclass(InterfaceP.class, InterfaceQ.class));
     assertTrue(canCallAsSubclass(InterfaceP[].class, Object.class));
     assertTrue(canCallAsSubclass(InterfaceP[].class, Object[].class));
     assertTrue(canCallAsSubclass(InterfaceR.class, InterfaceP.class));
-    assertTrue(!canCallAsSubclass(InterfaceR.class, InterfaceQ.class));
+    assertFalse(canCallAsSubclass(InterfaceR.class, InterfaceQ.class));
     assertTrue(canCallAsSubclass(InterfaceR.class, InterfaceR.class));
 
     assertTrue(canCallAsSubclass(AbstractClassX.class, Object.class));
-    assertTrue(!canCallAsSubclass(AbstractClassX.class, AbstractClassY.class));
+    assertFalse(canCallAsSubclass(AbstractClassX.class, AbstractClassY.class));
     assertTrue(canCallAsSubclass(AbstractClassX[].class, Object.class));
     assertTrue(canCallAsSubclass(AbstractClassX[].class, Object[].class));
 
@@ -352,20 +352,20 @@ public class ClassTest extends TestCase {
     assertTrue(canCallAsSubclass(AbstractClassY.class, InterfaceP.class));
     assertTrue(canCallAsSubclass(AbstractClassY[].class, Object.class));
     assertTrue(canCallAsSubclass(AbstractClassY[].class, Object[].class));
-    assertTrue(!canCallAsSubclass(AbstractClassY[].class, InterfaceP.class));
+    assertFalse(canCallAsSubclass(AbstractClassY[].class, InterfaceP.class));
     assertTrue(canCallAsSubclass(AbstractClassY[].class, InterfaceP[].class));
 
     assertTrue(canCallAsSubclass(ConcreteClassA.class, AbstractClassX.class));
-    assertTrue(!canCallAsSubclass(ConcreteClassA.class, AbstractClassY.class));
+    assertFalse(canCallAsSubclass(ConcreteClassA.class, AbstractClassY.class));
     assertTrue(canCallAsSubclass(ConcreteClassA[].class, AbstractClassX[].class));
 
     assertTrue(canCallAsSubclass(ConcreteClassB.class, AbstractClassY.class));
     assertTrue(canCallAsSubclass(ConcreteClassB.class, InterfaceP.class));
-    assertTrue(!canCallAsSubclass(ConcreteClassB.class, InterfaceQ.class));
+    assertFalse(canCallAsSubclass(ConcreteClassB.class, InterfaceQ.class));
     assertTrue(canCallAsSubclass(ConcreteClassB[].class, AbstractClassY[].class));
     assertTrue(canCallAsSubclass(ConcreteClassB[].class, InterfaceP[].class));
 
-    assertTrue(!canCallAsSubclass(ConcreteClassC.class, ConcreteClassA.class));
+    assertFalse(canCallAsSubclass(ConcreteClassC.class, ConcreteClassA.class));
     assertTrue(canCallAsSubclass(ConcreteClassC.class, ConcreteClassB.class));
     assertTrue(canCallAsSubclass(ConcreteClassC.class, InterfaceQ.class));
     assertTrue(canCallAsSubclass(ConcreteClassC[].class, ConcreteClassB[].class));
@@ -375,7 +375,7 @@ public class ClassTest extends TestCase {
     assertTrue(canCallAsSubclass(ConcreteClassD.class, InterfaceQ.class));
 
     assertTrue(canCallAsSubclass(ConcreteClassE.class, AbstractClassX.class));
-    assertTrue(!canCallAsSubclass(ConcreteClassE.class, AbstractClassY.class));
+    assertFalse(canCallAsSubclass(ConcreteClassE.class, AbstractClassY.class));
     assertTrue(canCallAsSubclass(ConcreteClassE.class, InterfaceP.class));
     assertTrue(canCallAsSubclass(ConcreteClassE.class, InterfaceQ.class));
   }

--- a/jre_emul/Tests/com/google/j2objc/ClassTest.java
+++ b/jre_emul/Tests/com/google/j2objc/ClassTest.java
@@ -311,6 +311,75 @@ public class ClassTest extends TestCase {
     assertEquals(CharSequence.class, Class.forName("java.lang.CharSequence"));
   }
 
+  boolean canCallAsSubclass(Class<?> x, Class<?> y) {
+    boolean callSuccessful;
+    try {
+      Class<?> z = x.asSubclass(y);
+      callSuccessful = true;
+    } catch (ClassCastException e) {
+      callSuccessful = false;
+    }
+
+    boolean assignable = y.isAssignableFrom(x);
+    assertEquals(assignable, callSuccessful);
+    return callSuccessful;
+  }
+
+  public void testAsSubclassCalls() throws Exception {
+    assertTrue(canCallAsSubclass(Integer.class, Object.class));
+    assertTrue(!canCallAsSubclass(Long.class, Integer.class));
+    assertTrue(canCallAsSubclass(Integer[].class, Object[].class));
+    assertTrue(canCallAsSubclass(Integer[].class, Object.class));
+    assertTrue(!canCallAsSubclass(int.class, Object.class));
+    assertTrue(!canCallAsSubclass(int.class, long.class));
+    assertTrue(canCallAsSubclass(int[].class, Object.class));
+    assertTrue(!canCallAsSubclass(int[].class, Object[].class));
+
+    assertTrue(canCallAsSubclass(InterfaceP.class, Object.class));
+    assertTrue(!canCallAsSubclass(InterfaceP.class, InterfaceQ.class));
+    assertTrue(canCallAsSubclass(InterfaceP[].class, Object.class));
+    assertTrue(canCallAsSubclass(InterfaceP[].class, Object[].class));
+    assertTrue(canCallAsSubclass(InterfaceR.class, InterfaceP.class));
+    assertTrue(!canCallAsSubclass(InterfaceR.class, InterfaceQ.class));
+    assertTrue(canCallAsSubclass(InterfaceR.class, InterfaceR.class));
+
+    assertTrue(canCallAsSubclass(AbstractClassX.class, Object.class));
+    assertTrue(!canCallAsSubclass(AbstractClassX.class, AbstractClassY.class));
+    assertTrue(canCallAsSubclass(AbstractClassX[].class, Object.class));
+    assertTrue(canCallAsSubclass(AbstractClassX[].class, Object[].class));
+
+    assertTrue(canCallAsSubclass(AbstractClassY.class, Object.class));
+    assertTrue(canCallAsSubclass(AbstractClassY.class, InterfaceP.class));
+    assertTrue(canCallAsSubclass(AbstractClassY[].class, Object.class));
+    assertTrue(canCallAsSubclass(AbstractClassY[].class, Object[].class));
+    assertTrue(!canCallAsSubclass(AbstractClassY[].class, InterfaceP.class));
+    assertTrue(canCallAsSubclass(AbstractClassY[].class, InterfaceP[].class));
+
+    assertTrue(canCallAsSubclass(ConcreteClassA.class, AbstractClassX.class));
+    assertTrue(!canCallAsSubclass(ConcreteClassA.class, AbstractClassY.class));
+    assertTrue(canCallAsSubclass(ConcreteClassA[].class, AbstractClassX[].class));
+
+    assertTrue(canCallAsSubclass(ConcreteClassB.class, AbstractClassY.class));
+    assertTrue(canCallAsSubclass(ConcreteClassB.class, InterfaceP.class));
+    assertTrue(!canCallAsSubclass(ConcreteClassB.class, InterfaceQ.class));
+    assertTrue(canCallAsSubclass(ConcreteClassB[].class, AbstractClassY[].class));
+    assertTrue(canCallAsSubclass(ConcreteClassB[].class, InterfaceP[].class));
+
+    assertTrue(!canCallAsSubclass(ConcreteClassC.class, ConcreteClassA.class));
+    assertTrue(canCallAsSubclass(ConcreteClassC.class, ConcreteClassB.class));
+    assertTrue(canCallAsSubclass(ConcreteClassC.class, InterfaceQ.class));
+    assertTrue(canCallAsSubclass(ConcreteClassC[].class, ConcreteClassB[].class));
+    assertTrue(canCallAsSubclass(ConcreteClassC[].class, InterfaceQ[].class));
+
+    assertTrue(canCallAsSubclass(ConcreteClassD.class, InterfaceP.class));
+    assertTrue(canCallAsSubclass(ConcreteClassD.class, InterfaceQ.class));
+
+    assertTrue(canCallAsSubclass(ConcreteClassE.class, AbstractClassX.class));
+    assertTrue(!canCallAsSubclass(ConcreteClassE.class, AbstractClassY.class));
+    assertTrue(canCallAsSubclass(ConcreteClassE.class, InterfaceP.class));
+    assertTrue(canCallAsSubclass(ConcreteClassE.class, InterfaceQ.class));
+  }
+
   static class InnerClass {
   }
 
@@ -325,6 +394,36 @@ public class ClassTest extends TestCase {
 
   static enum InnerEnum {
     A, B, C;
+  }
+
+  interface InterfaceP {
+  }
+
+  interface InterfaceQ {
+
+  }
+  interface InterfaceR extends InterfaceP {
+  }
+
+  static abstract class AbstractClassX {
+  }
+
+  static abstract class AbstractClassY implements InterfaceP {
+  }
+
+  class ConcreteClassA extends AbstractClassX {
+  }
+
+  class ConcreteClassB extends AbstractClassY {
+  }
+
+  class ConcreteClassC extends ConcreteClassB implements InterfaceQ {
+  }
+
+  class ConcreteClassD implements InterfaceP, InterfaceQ {
+  }
+
+  class ConcreteClassE extends AbstractClassX implements InterfaceP, InterfaceQ {
   }
 }
 


### PR DESCRIPTION
This fixes #563 and bases `-[IOSClass asSubclass]` on `-[IOSClass isAssignableFrom]`. This takes away the need to implement `-asSubclass` in `IOSConcreteclass` and bring the behavior in line with other implementations ([example](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/lang/Class.java#l3266)). A test case is also supplied.
