### PR TITLE
Keep the do statement body if the const expression is false 

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/ConstantBranchPruner.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/ConstantBranchPruner.java
@@ -42,7 +42,7 @@ public class ConstantBranchPruner extends TreeVisitor {
   @Override
   public void endVisit(DoStatement node) {
     if (getValue(node.getExpression()) == FALSE) {
-      node.remove();
+      node.replaceWith(node.getBody().copy());
     }
   }
 

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/ConstantBranchPrunerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/ConstantBranchPrunerTest.java
@@ -44,6 +44,19 @@ public class ConstantBranchPrunerTest extends GenerationTest {
     assertTranslatedLines(translation, "do {", "[self tick];", "}", "while (b);");
   }
 
+  // Verify body replaces do statement when false.
+  public void testFalseDoExpression() throws IOException {
+    String translation = translateSourceFile(
+        "class Test { int test() { foo: do { return 1; } while (false); }}",
+        "Test", "Test.m");
+    assertTranslatedLines(translation, "- (jint)test {", "foo: {", "return 1;", "}", "}");
+    translation = translateSourceFile(
+        "class Test { static final boolean debug = false;"
+            + "  int test() { foo: do { return 1; } while (debug); }}",
+        "Test", "Test.m");
+    assertTranslatedLines(translation, "- (jint)test {", "foo: {", "return 1;", "}", "}");
+  }
+
   // Verify then block replaces if statement when true.
   public void testTrueIfExpression() throws IOException {
     String translation = translateSourceFile(


### PR DESCRIPTION
This fixes #569, that the body of a `do` statement with constant `false` expression is erroneously skipped. A test case is also added.
