### PR TITLE
Provide more system properties, such as os.arch (fixes #565)

### DIFF
--- a/jre_emul/Tests/java/lang/SystemTest.java
+++ b/jre_emul/Tests/java/lang/SystemTest.java
@@ -40,6 +40,63 @@ import java.util.Map;
  */
 public class SystemTest extends TestCase {
 
+  static final String[] NOT_NULL_PROPERTIES = {
+      "file.separator",
+      "java.class.path",
+      "java.class.version",
+      "java.compiler",
+      "java.ext.dirs",
+      "java.home",
+      "java.io.tmpdir",
+      "java.library.path",
+      "java.specification.name",
+      "java.specification.vendor",
+      "java.specification.version",
+      "java.vendor",
+      "java.vendor.url",
+      "java.version",
+      "java.vm.name",
+      "java.vm.specification.name",
+      "java.vm.specification.vendor",
+      "java.vm.specification.version",
+      "java.vm.vendor",
+      "java.vm.version",
+      "line.separator",
+      "os.arch",
+      "os.name",
+      "os.version",
+      "path.separator",
+      "user.dir",
+      "user.home",
+      "user.name",
+  };
+
+  static final String[] NOT_EMPTY_PROPERTIES = {
+      "file.separator",
+      "java.class.version",
+      "java.home",
+      "java.io.tmpdir",
+      "java.specification.name",
+      "java.specification.vendor",
+      "java.specification.version",
+      "java.vendor",
+      "java.vendor.url",
+      "java.version",
+      "java.vm.specification.name",
+      "java.vm.specification.vendor",
+      "java.vm.specification.version",
+      "java.vm.vendor",
+      "java.vm.version",
+      "line.separator",
+      "os.arch",
+      "os.name",
+      "os.version",
+      "path.separator",
+      "user.dir",
+      "user.home",
+      "user.name",
+  };
+
   public void testGetenvKey() {
     assertNotNull(System.getenv("HOME"));
     assertNull(System.getenv("SOME_VARIABLE_THAT_SHOULD_NOT_EXIST"));
@@ -56,6 +113,18 @@ public class SystemTest extends TestCase {
       fail("Should throw UnsupportedOperationException");
     } catch (UnsupportedOperationException e) {
       // expected
+    }
+  }
+
+  public void testSystemProperties() {
+    for (String key : NOT_NULL_PROPERTIES) {
+      assertNotNull(System.getProperty(key));
+    }
+
+    assertNull(System.getProperty("non.existent.property"));
+
+    for (String key : NOT_EMPTY_PROPERTIES) {
+      assertTrue(System.getProperty(key).length() > 0);
     }
   }
 }

--- a/make/fat_lib.mk
+++ b/make/fat_lib.mk
@@ -40,12 +40,18 @@ FAT_LIB_MACOSX_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh)
 FAT_LIB_IPHONE_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --iphoneos)
 FAT_LIB_SIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --iphonesimulator)
 
-FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -isysroot $(FAT_LIB_MACOSX_SDK_DIR)
-FAT_LIB_IPHONE_FLAGS = -arch armv7 -miphoneos-version-min=5.0 -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
-FAT_LIB_IPHONE64_FLAGS = -arch arm64 -miphoneos-version-min=5.0 -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
-FAT_LIB_IPHONEV7S_FLAGS = -arch armv7s -miphoneos-version-min=5.0 -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
-FAT_LIB_SIMULATOR_FLAGS = -arch i386 -miphoneos-version-min=5.0 -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
-FAT_LIB_XCODE_FLAGS = $(ARCH_FLAGS) -miphoneos-version-min=5.0 -isysroot $(SDKROOT)
+FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -DJ2OBJC_BUILD_ARCH=x86_64 \
+  -isysroot $(FAT_LIB_MACOSX_SDK_DIR)
+FAT_LIB_IPHONE_FLAGS = -arch armv7 -DJ2OBJC_BUILD_ARCH=armv7 -miphoneos-version-min=5.0 \
+  -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
+FAT_LIB_IPHONE64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=5.0 \
+  -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
+FAT_LIB_IPHONEV7S_FLAGS = -arch armv7s -DJ2OBJC_BUILD_ARCH=armv7s -miphoneos-version-min=5.0 \
+  -isysroot $(FAT_LIB_IPHONE_SDK_DIR)
+FAT_LIB_SIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -miphoneos-version-min=5.0 \
+  -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
+FAT_LIB_XCODE_FLAGS = $(ARCH_FLAGS) -DJ2OBJC_BUILD_ARCH=$(CURRENT_ARCH) -miphoneos-version-min=5.0 \
+  -isysroot $(SDKROOT)
 
 ifdef FAT_LIB_PRECOMPILED_HEADER
 ifndef CONFIGURATION_BUILD_DIR


### PR DESCRIPTION
This fixes #565 by providing more system properties such as `os.arch` and `os.version`. The values are selected according to the recommendations by @tomball in [this comment](https://github.com/google/j2objc/issues/565#issuecomment-119296137).

For `os.arch` I made changes to `fat_lib.mk` to pass the arch info via the `J2OBJC_BUILD_ARCH`. I'm not completely sure how the Makefile interacts with the Xcode project, and please let me know if I updated `FAT_LIB_XCODE_FLAGS` correctly, or if there are other places I also need to update.

For `os.version`, I decided to use the new `[NSProcessInfo processInfo].operatingSystemVersion` API before falling back to other means. I decided not to use the deprecated [Gestalt Manager](https://developer.apple.com/library/mac/documentation/Carbon/Reference/Gestalt_Manager/index.html) because the x86_64 portion of the fat library is also used by 64-bit iOS Simulator apps, and adding `Gestalt` would require apps to link against the OS X-only `CoreServices.framework`, and that wouldn't make sense. The drawback is that Mac apps that are built where the new API is not available will see the more verbose `[NSProcessInfo processInfo].operatingSystemVersionString` used. The string is localized and "not appropriate for parsing" according to Apple's API doc, but I guess for the use cases in #565 this code path does not warrant more complexity than it probably already has.

I didn't change the value of `user.dir` on OS X (although @tomball pointed out some issues [in the comment](https://github.com/google/j2objc/issues/565#issuecomment-119296137)). There's [a code comment about working around a simulator bug](https://github.com/google/j2objc/blob/d7c9091bfe305cfc58af29d8a8b10ee7f6ecdf9e/jre_emul/Classes/java/lang/System.java#L175), and so I decided not to do anything about it in this PR.
