### PR TITLE
Implement JreAssert with macro so that msg is conditionally evaluated

### DIFF
--- a/jre_emul/Classes/J2ObjC_source.h
+++ b/jre_emul/Classes/J2ObjC_source.h
@@ -44,13 +44,11 @@ __attribute__((always_inline)) inline id check_protocol_cast(
 
 FOUNDATION_EXPORT void JreThrowAssertionError(id __unsafe_unretained msg);
 
-__attribute__((always_inline)) inline void JreAssert(jboolean cond, id __unsafe_unretained msg) {
 #ifndef NS_BLOCK_ASSERTIONS
-  if (!cond) {
-    JreThrowAssertionError(msg);
-  }
+#define JreAssert(cond, msg) do { if (!(cond)) JreThrowAssertionError(msg); } while(0)
+#else
+#define JreAssert(cond, msg)
 #endif
-}
 
 // Only expose this function to ARC generated code.
 #if __has_feature(objc_arc)

--- a/jre_emul/Tests/com/google/j2objc/AssertTest.java
+++ b/jre_emul/Tests/com/google/j2objc/AssertTest.java
@@ -45,4 +45,13 @@ public class AssertTest extends TestCase {
     String x = null;
     assert x == null: "x should be null, but is a string of length " + x.length();
   }
+
+  /**
+   * Ensure that the condition and the expression passed to the JreAssert macro are wrapped with
+   * parentheses in the translated code.
+   */
+  public void testTranslationCorrectness() throws Exception {
+    assert new Integer[]{1, 2} != null;
+    assert true: new Integer[]{1, 2};
+  }
 }

--- a/jre_emul/Tests/com/google/j2objc/AssertTest.java
+++ b/jre_emul/Tests/com/google/j2objc/AssertTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.j2objc;
+
+import junit.framework.TestCase;
+
+public class AssertTest extends TestCase {
+  String evaluationResult;
+
+  String setMessage(String msg) {
+    evaluationResult = msg;
+    return evaluationResult;
+  }
+
+  /**
+   * Ensure that JreAssert only evaluates Expression2 when Expression1 is false, in accordance with
+   * the Java Language Specification.
+   */
+  public void testNonEvaluationOfExpression2() throws Exception {
+    assertNull(evaluationResult);
+
+    assert true: "msg: " + setMessage("error");
+    assertNull("evalutationResult should not be set", evaluationResult);
+
+    try {
+      assert false: "msg: " + setMessage("real error");
+    } catch (AssertionError e) {
+      assertEquals("msg: real error", e.getMessage());
+    }
+    assertEquals("real error", evaluationResult);
+
+    // A case where eager evalutaion of Expression2 would crash the program.
+    String x = null;
+    assert x == null: "x should be null, but is a string of length " + x.length();
+  }
+}

--- a/jre_emul/tests.mk
+++ b/jre_emul/tests.mk
@@ -145,6 +145,7 @@ TEST_SOURCES := \
     android/text/TextUtilsTest.java \
     android/util/Base64Test.java \
     com/google/j2objc/ArrayTest.java \
+    com/google/j2objc/AssertTest.java \
     com/google/j2objc/ClassTest.java \
     com/google/j2objc/PackageTest.java \
     com/google/j2objc/ThrowableTest.java \

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -238,9 +238,9 @@ public class StatementGenerator extends TreeVisitor {
 
   @Override
   public boolean visit(AssertStatement node) {
-    buffer.append("JreAssert(");
+    buffer.append("JreAssert((");
     node.getExpression().accept(this);
-    buffer.append(", ");
+    buffer.append("), (");
     if (node.getMessage() != null) {
       node.getMessage().accept(this);
     } else {
@@ -254,7 +254,7 @@ public class StatementGenerator extends TreeVisitor {
           + " condition failed: " + assertStatementString;
       buffer.append(LiteralGenerator.generateStringLiteral(msg));
     }
-    buffer.append(");\n");
+    buffer.append("));\n");
     return false;
   }
 

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
@@ -1205,7 +1205,7 @@ public class StatementGeneratorTest extends GenerationTest {
         + "int a = 5;\nint b = 6;\nassert a < b;\n}\n}\n",
         "Test", "Test.m");
     assertTranslation(translation,
-        "JreAssert(a < b, @\"Test.java:4 condition failed: assert a < b;\")");
+        "JreAssert((a < b), (@\"Test.java:4 condition failed: assert a < b;\"))");
   }
 
   public void testAssertWithDescription() throws IOException {
@@ -1214,7 +1214,7 @@ public class StatementGeneratorTest extends GenerationTest {
         + "int a = 5; int b = 6; assert a < b : \"a should be lower than b\";}}",
         "Test", "Test.m");
     assertTranslation(translation,
-        "JreAssert(a < b, @\"a should be lower than b\")");
+        "JreAssert((a < b), (@\"a should be lower than b\"))");
   }
 
   public void testAssertWithDynamicDescription() throws IOException {
@@ -1223,7 +1223,7 @@ public class StatementGeneratorTest extends GenerationTest {
         + "int a = 5; int b = 6; assert a < b : a + \" should be lower than \" + b;}}",
         "Test", "Test.m");
     assertTranslation(translation,
-        "JreAssert(a < b, JreStrcat(\"I$I\", a, @\" should be lower than \", b));");
+        "JreAssert((a < b), (JreStrcat(\"I$I\", a, @\" should be lower than \", b)));");
   }
 
   // Verify that a Unicode escape sequence is preserved with string

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
@@ -441,7 +441,7 @@ public class AutoboxerTest extends GenerationTest {
     String translation = translateSourceFile(
         "class Test { void test(int i) { assert i == 0 : i; }}", "Test", "Test.m");
     assertTranslation(translation,
-        "JreAssert(i == 0, JavaLangInteger_valueOfWithInt_(i));");
+        "JreAssert((i == 0), (JavaLangInteger_valueOfWithInt_(i)));");
   }
 
   public void testNonWrapperObjectTypeCastToPrimitive() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/UnsequencedExpressionRewriterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/UnsequencedExpressionRewriterTest.java
@@ -137,7 +137,7 @@ public class UnsequencedExpressionRewriterTest extends GenerationTest {
         "jint unseq$1 = i++;",
         "jboolean unseq$2 = unseq$1 + i++ == 0;",
         "jint unseq$3 = i++;",
-        "JreAssert(unseq$2, JreStrcat(\"$II\", @\"foo\", unseq$3, i++));");
+        "JreAssert((unseq$2), (JreStrcat(\"$II\", @\"foo\", unseq$3, i++)));");
   }
 
   public void testForInitStatements() throws IOException {


### PR DESCRIPTION
This fixes #590 by using macro to implement `JreAssert`. A new test case is also added and has been run first without then with the change.