### PR TITLE
Improve dead code elimination

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/pipeline/TranslationProcessor.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/pipeline/TranslationProcessor.java
@@ -158,7 +158,7 @@ public class TranslationProcessor extends FileProcessor {
     ticker.tick("InnerClassExtractor");
 
     // Normalize init statements
-    new InitializationNormalizer().run(unit);
+    new InitializationNormalizer(deadCodeMap).run(unit);
     ticker.tick("InitializationNormalizer");
 
     // Fix references to outer scope and captured variables.

--- a/translator/src/main/java/com/google/devtools/j2objc/util/DeadCodeMap.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/DeadCodeMap.java
@@ -80,6 +80,7 @@ public class DeadCodeMap {
   private final ImmutableSet<String> deadClasses;
   private final ImmutableTable<String, String, ImmutableSet<String>> deadMethods;
   private final ImmutableMultimap<String, String> deadFields;
+  private final Set<String> hasConstructorRemovedClasses = new HashSet<>();
 
   private DeadCodeMap(
       ImmutableSet<String> deadClasses,
@@ -105,5 +106,13 @@ public class DeadCodeMap {
 
   public boolean isEmpty() {
     return deadClasses.isEmpty() && deadMethods.isEmpty() && deadFields.isEmpty();
+  }
+
+  public void addConstructorRemovedClass(String clazz) {
+    hasConstructorRemovedClasses.add(clazz);
+  }
+
+  public boolean classHasConstructorRemoved(String clazz) {
+    return hasConstructorRemovedClasses.contains(clazz);
   }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/InitializationNormalizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/InitializationNormalizerTest.java
@@ -17,11 +17,12 @@
 package com.google.devtools.j2objc.translate;
 
 import com.google.devtools.j2objc.GenerationTest;
+import com.google.devtools.j2objc.util.DeadCodeMap;
 
 import java.io.IOException;
 
 /**
- * Unit tests for {@link InitializationNormalization} phase.
+ * Unit tests for {@link InitializationNormalizer} phase.
  *
  * @author Tom Ball
  */
@@ -34,7 +35,7 @@ public class InitializationNormalizerTest extends GenerationTest {
   @Override
   protected void setUp() throws IOException {
     super.setUp();
-    instance = new InitializationNormalizer();
+    instance = new InitializationNormalizer(new DeadCodeMap.Builder().build());
   }
 
   /**


### PR DESCRIPTION
This fixes the cases discussed in #599 with changes to `DeadCodeEliminator`. This requires that the dead code map be passed to `InitializationNormalizer` later in the translation process, though. I've also added the discussed test cases. Improvements include:

* Don't remove static nested classes from a dead class
* Also visit static nested classes in a dead class
* Be more strict about what makes a value inlinable
* Don't call super from the generated default constructor if the entire class is dead or if all constructors are dead
