### PR TITLE
Fix memory leaks in Throwable

### DIFF
--- a/jre_emul/Classes/java/lang/Throwable.m
+++ b/jre_emul/Classes/java/lang/Throwable.m
@@ -348,6 +348,7 @@ static BOOL ShouldFilterStackElement(JavaLangStackTraceElement *element) {
   [cause release];
   [detailMessage release];
   [stackTrace release];
+  [suppressedExceptions release];
   [super dealloc];
 }
 


### PR DESCRIPTION
This fixes the leaks in `Throwable` (#601). Currently the only place where `suppressedExceptions` is released is when `-[Throwable addSuppressedWithJavaLangThrowable:]` is called. I wasn't sure if `suppressedExceptions` is used/handled elsewhere, but in jre_emul `suppressedExceptions` only appears in `Throwable.m`, so I thought this should be released in `-dealloc`.
