### PR TITLE
Fix FileChannelImpl and FileLock memory leaks

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/nio/FileChannelImpl.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/nio/FileChannelImpl.java
@@ -17,6 +17,8 @@
 
 package java.nio;
 
+import com.google.j2objc.annotations.Weak;
+
 import java.io.Closeable;
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -50,6 +52,7 @@ final class FileChannelImpl extends FileChannel {
         }
     };
 
+    @Weak
     private final Object stream;
     private final FileDescriptor fd;
     private final int mode;

--- a/jre_emul/android/libcore/luni/src/main/java/java/nio/channels/FileLock.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/nio/channels/FileLock.java
@@ -17,6 +17,8 @@
 
 package java.nio.channels;
 
+import com.google.j2objc.annotations.Weak;
+
 import java.io.IOException;
 
 /**
@@ -71,6 +73,7 @@ import java.io.IOException;
 public abstract class FileLock implements AutoCloseable {
 
     // The underlying file channel.
+    @Weak
     private final FileChannel channel;
 
     // The lock starting position.


### PR DESCRIPTION
This fixes the leaks in `FileChannelImpl` and `FileLock` as discussed in #603 .