### PR TITLE
Fix the "lock = this" pattern in Reader, Writer, and synchronized Collections

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/io/Reader.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/io/Reader.java
@@ -43,11 +43,12 @@ public abstract class Reader implements Readable, Closeable {
     protected Object lock;
 
     /**
-     * Constructs a new {@code Reader} with {@code this} as the object used to
-     * synchronize critical sections.
+     * Constructs a new {@code Reader} with a lock object to synchronize
+     * critical sections.
      */
     protected Reader() {
-        lock = this;
+        // j2objc: Use a new object rather than this to avoid reference cycle.
+        lock = new Object();
     }
 
     /**

--- a/jre_emul/android/libcore/luni/src/main/java/java/io/Writer.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/io/Writer.java
@@ -41,11 +41,12 @@ public abstract class Writer implements Appendable, Closeable, Flushable {
     protected Object lock;
 
     /**
-     * Constructs a new {@code Writer} with {@code this} as the object used to
-     * synchronize critical sections.
+     * Constructs a new {@code Writer} with a lock object to synchronize
+     * critical sections.
      */
     protected Writer() {
-        lock = this;
+        // j2objc: Use a new object rather than this to avoid reference cycle.
+        lock = new Object();
     }
 
     /**

--- a/jre_emul/android/libcore/luni/src/main/java/java/util/Collections.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/Collections.java
@@ -367,7 +367,8 @@ public class Collections {
 
         SynchronizedCollection(Collection<E> collection) {
             c = collection;
-            mutex = this;
+            // j2objc: Use a new object rather than this to avoid reference cycle.
+            mutex = new Object();
         }
 
         SynchronizedCollection(Collection<E> collection, Object mutex) {
@@ -659,7 +660,8 @@ public class Collections {
 
         SynchronizedMap(Map<K, V> map) {
             m = map;
-            mutex = this;
+            // j2objc: Use a new object rather than this to avoid reference cycle.
+            mutex = new Object();
         }
 
         SynchronizedMap(Map<K, V> map, Object mutex) {


### PR DESCRIPTION
This fixes #605 following @tomball's suggestion that we can just use a new object for the lock.

I'm a little curious what happens when j2objc wants to merge the next version of Android source. Would this kind of fix cause future maintenance issues?
