### PR TITLE
Fix premature release in canceled FutureTask

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/util/concurrent/FutureTask.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/concurrent/FutureTask.java
@@ -274,7 +274,7 @@ public class FutureTask<V> implements RunnableFuture<V> {
         boolean ran = false;
         int s = state;
         try {
-            Callable<V> c = callable;
+            @RetainedLocalRef Callable<V> c = callable;
             if (c != null && s == NEW) {
                 try {
                     c.call(); // don't set result

--- a/jre_emul/android/libcore/luni/src/main/java/java/util/concurrent/FutureTask.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/concurrent/FutureTask.java
@@ -6,6 +6,8 @@
 
 package java.util.concurrent;
 
+import com.google.j2objc.annotations.RetainedLocalRef;
+
 import java.util.concurrent.locks.LockSupport;
 
 /**
@@ -229,7 +231,7 @@ public class FutureTask<V> implements RunnableFuture<V> {
             !U.compareAndSwapObject(this, RUNNER, null, Thread.currentThread()))
             return;
         try {
-            Callable<V> c = callable;
+            @RetainedLocalRef Callable<V> c = callable;
             if (c != null && state == NEW) {
                 V result;
                 boolean ran;


### PR DESCRIPTION
If a FutureTask is already running when it is canceled by another thread, the Callable in the FutureTask is released immediately and the Callable.call method can crash it it references `this`. This fix makes sure the FutureTask keeps a local retained reference to the Callable while it runs.

Fixes issue #622 (ThreadPoolExecutor releases tasks prematurely when interrupted).