### PR TITLE
Small edits to Memory Model page.

### DIFF
--- a/docs/Memory-Model.md
+++ b/docs/Memory-Model.md
@@ -11,7 +11,7 @@ This document describes how memory is managed under J2ObjC translated code, and 
 
 One of J2ObjC's goals is to produce translated code that will integrate seamlessly into Objective-C's reference counting environment. This makes translated Java code easy to use from natively written Objective-C because there is no awkward transfer of ownership for objects being passed between Java and Objective-C environments.
 
-Since Java uses garbage collection for memory management, Java code contains no explicit memory management of it's objects. J2ObjC must therefore insert reference counting calls appropriately to ensure that objects are deallocated at the right time. We have settled on the following set of rules that we've found to be both performant and practical:
+Since Java uses garbage collection for memory management, Java code contains no explicit memory management of its objects. J2ObjC must therefore insert reference counting calls appropriately to ensure that objects are deallocated at the right time. We have settled on the following set of rules that we've found to be both performant and practical:
 * All objects will live for at least the duration of the current autorelease pool.
   * This general rule allows us to skip many retains and releases that would otherwise be necessary.
 * Local variables are not retained.
@@ -22,7 +22,7 @@ Since Java uses garbage collection for memory management, Java code contains no 
 
 ### Reference Cycles
 
-It is possible for memory leaks to occur in translated code. This is an unavoidable side-effect of mapping from a garbage collected environment to a reference counted environment. Leaks occur when reference cycles are created. A reference cycle exists when an object refers to itself either directly or indirectly through it's fields. There is no automated way to prevent reference cycles from occuring, however we do provide a [Cycle Finder](Cycle-Finder-Tool.html) tool that automates detection of cycles. Here are some common ways to fix a reference cycle:
+It is possible for memory leaks to occur in translated code. This is an unavoidable side-effect of mapping from a garbage collected environment to a reference counted environment. Leaks occur when reference cycles are created in the Java source. A reference cycle exists when an object refers to itself either directly or indirectly through it's fields. There is no automated way to prevent reference cycles from occuring; however, we do provide a [Cycle Finder](Cycle-Finder-Tool.html) tool that automates detection of cycles. Here are some common ways to fix a reference cycle:
 * Add a [@Weak](Weak.html) or [@WeakOuter](WeakOuter.html) annotation to weaken one of the references.
 * Add a `cleanup()` method to one of the objects that sets some fields to null. Call `cleanup()` before discarding the object.
 * Redesign the code to avoid creating a reference cycle altogether.
@@ -38,9 +38,9 @@ J2ObjC maps the `synchronized` keyword directly to Objective-C `@synchronized`.
 ### Atomicity
 
 Java guarantees atomicity for loads and stores of all types except `long` and `double`. See [JLS-17.7](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7). With the exception of `volatile` types (described below) J2ObjC provides no special treatment to ensure atomic loads and stores. This implies the following:
-* Since all iOS platforms are 32 or 64 bit, loads and stores of primitive types except `long` and `double` are atomic.
+* Since all iOS platforms are 32 or 64-bit, loads and stores of primitive types except `long` and `double` are atomic on 32-bit devices, and all are atomic on 64-bit systems.
 * Loads and stores of object types are not atomic in J2ObjC.
-  * Atomically updating reference counts would be too costly.
+  * Atomically updating reference counts is too costly.
   * An object field can be made atomic by declaring it `volatile`. (see below)
   
 ### Volatile fields
@@ -51,11 +51,11 @@ For `volatile` fields, Java provides both atomicity and sequencially consistent 
 * Object fields are protected with spin locks.
   * Mutual exclusion is necessary to prevent race conditions with the reference counting.
   * The implementation is very similar to Objective-C atomic properties.
-  
-### Final fields
-
-TODO(kstanger): Java provides memory ordering semantics for final fields that are not yet supported by J2ObjC. ([JSL-17.5](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.5))
 
 ### Atomic Types
 
 Java provides a number of atomic types in the [java.util.concurrent.atomic](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html) package. These are all fully supported in J2ObjC with custom implementations.
+  
+### Final fields
+
+[Issue 629](https://github.com/google/j2objc/issues/629): Java provides memory ordering semantics for final fields that are not yet supported by J2ObjC. ([JSL-17.5](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.5))


### PR DESCRIPTION
In the future, keeping lines < 100 columns will make the diffs easier to review.