### PR TITLE
Update Number.java for Long serializable

### DIFF
--- a/jre_emul/stub_classes/java/lang/Number.java
+++ b/jre_emul/stub_classes/java/lang/Number.java
@@ -22,12 +22,12 @@ package java.lang;
  *
  * @see java.lang.Object
  */
-public abstract class Number {
+public abstract class Number implements java.io.Serializable {
 
   public Number() {}
 
   public byte byteValue() {
-	  return 0;
+	  return (byte)intValue();
   }
 
   public abstract double doubleValue();
@@ -39,6 +39,8 @@ public abstract class Number {
   public abstract long longValue();
 
   public short shortValue() {
-    return 0;
+    return (short)intValue();
   }
+  
+  private static final long serialVersionUID = -8742448824652078965L
 }

--- a/jre_emul/stub_classes/java/lang/Number.java
+++ b/jre_emul/stub_classes/java/lang/Number.java
@@ -27,7 +27,7 @@ public abstract class Number implements java.io.Serializable {
   public Number() {}
 
   public byte byteValue() {
-	  return (byte)intValue();
+	  return 0;
   }
 
   public abstract double doubleValue();
@@ -39,7 +39,7 @@ public abstract class Number implements java.io.Serializable {
   public abstract long longValue();
 
   public short shortValue() {
-    return (short)intValue();
+    return 0;
   }
   
   private static final long serialVersionUID = -8742448824652078965L


### PR DESCRIPTION
Hi,
Sorry in advance for my poor english.
I've an error when I translate a class at who I pass a "Long" type when it expect a generic type serializable and comparable:
error: SimpleAutoIndexedEntity.java:15: Bound mismatch: The type Long is not a valid substitute for the bounded parameter <ID extends Serializable & Comparable<ID>> of the type SimpleEntity<ID>
It seems that it was because the Number.java (who is present in the jre_emul.jar file) doesn't implement java.io.Serializable. That's why "Long" class who inherit of the "Number" class can't be serializable.
I've compared to the official Number.java file from the java.lang package and there is other differences on byteValue and shortValue methods.
I don't know if it's necessary, or obligatory, to update this methods too, but this update seems work with it.
Do you think it's good?