### PR TITLE
Add toNSEnum() conversion method on generated JavaEnum subclasses

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
@@ -129,15 +129,24 @@ public class EnumRewriter extends TreeVisitor {
     String typeName = nameTable.getFullName(node.getTypeBinding());
     int numConstants = node.getEnumConstants().size();
 
-    String header = String.format(
+    StringBuilder header = new StringBuilder();
+
+    header.append(String.format(
         "+ (IOSObjectArray *)values;\n"
         + "FOUNDATION_EXPORT IOSObjectArray *%s_values();\n\n"
         + "+ (%s *)valueOfWithNSString:(NSString *)name;\n"
         + "FOUNDATION_EXPORT %s *%s_valueOfWithNSString_(NSString *name);\n\n"
-        + "- (id)copyWithZone:(NSZone *)zone;\n", typeName, typeName, typeName, typeName);
+        + "- (id)copyWithZone:(NSZone *)zone;\n", typeName, typeName, typeName, typeName));
 
-    StringBuilder sb = new StringBuilder();
-    sb.append(String.format(
+    // Strip enum type suffix.
+    String bareTypeName =
+          typeName.endsWith("Enum") ? typeName.substring(0, typeName.length() - 4) : typeName;
+
+    header.append(String.format(
+          "- (%s)toNSEnum;\n", bareTypeName));
+
+    StringBuilder implementation = new StringBuilder();
+    implementation.append(String.format(
         "IOSObjectArray *%s_values() {\n"
         + "  %s_initialize();\n"
         + "  return [IOSObjectArray arrayWithObjects:%s_values_ count:%s type:%s_class_()];\n"
@@ -146,12 +155,12 @@ public class EnumRewriter extends TreeVisitor {
         + "  return %s_values();\n"
         + "}\n\n", typeName, typeName, typeName, numConstants, typeName, typeName));
 
-    sb.append(String.format(
+    implementation.append(String.format(
         "+ (%s *)valueOfWithNSString:(NSString *)name {\n"
         + "  return %s_valueOfWithNSString_(name);\n"
         + "}\n\n", typeName, typeName));
 
-    sb.append(String.format(
+    implementation.append(String.format(
         "%s *%s_valueOfWithNSString_(NSString *name) {\n"
             + "  %s_initialize();\n"
             + "  for (int i = 0; i < %s; i++) {\n"
@@ -161,19 +170,24 @@ public class EnumRewriter extends TreeVisitor {
             + "    }\n"
             + "  }\n", typeName, typeName, typeName, numConstants, typeName, typeName));
     if (Options.useReferenceCounting()) {
-      sb.append(
+      implementation.append(
           "  @throw [[[JavaLangIllegalArgumentException alloc] initWithNSString:name]"
           + " autorelease];\n");
     } else {
-      sb.append("  @throw [[JavaLangIllegalArgumentException alloc] initWithNSString:name];\n");
+      implementation.append("  @throw [[JavaLangIllegalArgumentException alloc] initWithNSString:name];\n");
     }
-    sb.append("  return nil;\n}\n\n");
+    implementation.append("  return nil;\n}\n\n");
+
+    implementation.append(String.format(
+        "- (%s)toNSEnum {\n"
+            + "  return (%s)[self ordinal];\n"
+            + "}\n\n", bareTypeName, bareTypeName));
 
     // Enum constants needs to implement NSCopying.  Being singletons, they
     // can just return self, as long the retain count is incremented.
     String selfString = Options.useReferenceCounting() ? "[self retain]" : "self";
-    sb.append(String.format("- (id)copyWithZone:(NSZone *)zone {\n  return %s;\n}\n", selfString));
+    implementation.append(String.format("- (id)copyWithZone:(NSZone *)zone {\n  return %s;\n}\n", selfString));
 
-    node.getBodyDeclarations().add(new NativeDeclaration(header, sb.toString()));
+    node.getBodyDeclarations().add(new NativeDeclaration(header.toString(), implementation.toString()));
   }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/EnumRewriterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/EnumRewriterTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.j2objc.translate;
 
 import com.google.devtools.j2objc.GenerationTest;
+import org.junit.Assert;
 
 import java.io.IOException;
 
@@ -35,4 +36,15 @@ public class EnumRewriterTest extends GenerationTest {
     assertTranslation(translation,
         "TestEnum_A = new_TestEnum_initWithId_withNSString_withInt_(@\"foo\", @\"A\", 0);");
   }
+
+  public void testToNsEnumConversion() throws Exception {
+    String translation = translateSourceFile(
+        "enum Test { A }", "Test", "Test.m");
+    assertTranslatedLines(translation,
+        "- (Test)toNSEnum {",
+        "  return (Test)[self ordinal];",
+        "}");
+  }
 }
+
+


### PR DESCRIPTION
This addresses the following feature request:
  https://github.com/google/j2objc/issues/643

Add support for converting a JavaEnum instance to it's associated NSEnum value.

Example:
Lets say I have the following Java classes:

```
    public enum CardSuit {
        HEARTS,
        DIAMONDS,
        CLUBS,
        SPADES
    }

    public interface PlayingCard {
        CardSuit getSuit();
        int getRank();
    }
    
```

While translating, generates a method like this (Java syntax):

```
CardSuit.HEARTS.toNsEnum()
```



## Examples

_Usage in Objective-c_

```
- (NSString *)imageNameForPlayingCard:(id <PlayingCard>)playingCard {
    switch ([playingCard getSuit] toNSEnum]) {
        case CardSuit_HEARTS:
            return @"suit_hearts";
        case CardSuit_DIAMONDS:
            return @"suit_diamonds";
        case CardSuit_CLUBS:
            return @"suit_clubs";
        case CardSuit_SPADES:
            return @"suit_spades";
    }

```


_Usage in Swift_

```
    public func imageNameForPlayingCard(playingCard: PlayingCard) -> String {
        switch (playingCard.getSuit().toNSEnum()) {
        case .HEARTS:
            return "suit_hearts";
        case .DIAMONDS:
            return "suit_diamonds";
        case .CLUBS:
            return "suit_clubs";
        case .SPADES:
            return "suit_spades";
        }
    }

```

## Implementation

Adds the following code to the generated Objective-C code:

_CardSuite.h file_


```
typedef NS_ENUM(NSUInteger, CardSuit) {
  CardSuit_HEARTS = 0,
  CardSuit_DIAMONDS = 1,
  CardSuit_CLUBS = 2,
  CardSuit_SPADES = 3,
};

@interface CardSuitEnum : JavaLangEnum < NSCopying >
    ...
    - (CardSuit)toNSEnum;  // <-- NEW!
@end
```


_CardSuite.m_

```
@implementation CardSuitEnum
...
    // NEW -->
    - (CardSuit) toNSEnum {
    	return (CardSuit)ordinal;
    }
    // <-- NEW
    
@end
```