### PR TITLE
Segmented-headers defaults to true

### DIFF
--- a/doc/man/j2objc.1
+++ b/doc/man/j2objc.1
@@ -106,8 +106,8 @@ Names of the annotation processors to run; bypasses default discovery process.
 .BI \-processorpath " path "
 Specify where to find annotation processors.
 .TP
-\fB\-\-segmented\-headers\fR
-Generates headers with guards around each declared type. Useful for breaking import cycles.
+\fB\-\-no\-segmented\-headers\fR
+Do not generate headers with guards around each declared type.
 .TP
 .BI \-\-static\-accessor\-methods
 Generates accessor methods for static variables and enum constants.

--- a/translator/src/main/java/com/google/devtools/j2objc/Options.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/Options.java
@@ -741,11 +741,6 @@ public class Options {
     return instance.segmentedHeaders;
   }
 
-  @VisibleForTesting
-  public static void enableSegmentedHeaders() {
-    instance.segmentedHeaders = true;
-  }
-
   public static boolean jsniWarnings() {
     return instance.jsniWarnings;
   }

--- a/translator/src/main/java/com/google/devtools/j2objc/Options.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/Options.java
@@ -76,7 +76,7 @@ public class Options {
   private Map<String, String> classMappings = Maps.newLinkedHashMap();
   private Map<String, String> methodMappings = Maps.newLinkedHashMap();
   private boolean stripGwtIncompatible = false;
-  private boolean segmentedHeaders = false;
+  private boolean segmentedHeaders = true;
   private String fileEncoding = System.getProperty("file.encoding", "UTF-8");
   private boolean jsniWarnings = true;
   private boolean buildClosure = false;
@@ -347,8 +347,8 @@ public class Options {
         stripGwtIncompatible = true;
       } else if (arg.equals("--strip-reflection")) {
         stripReflection = true;
-      } else if (arg.equals("--segmented-headers")) {
-        segmentedHeaders = true;
+      } else if (arg.equals("--no-segmented-headers")) {
+        segmentedHeaders = false;
       } else if (arg.equals("--build-closure")) {
         buildClosure = true;
       } else if (arg.equals("--extract-unsequenced")) {
@@ -380,7 +380,8 @@ public class Options {
       else if (arg.equals("--final-methods-as-functions")
           || arg.equals("--no-final-methods-functions")
           || arg.equals("--hide-private-members")
-          || arg.equals("--no-hide-private-members")) {
+          || arg.equals("--no-hide-private-members")
+          || arg.equals("--segmented-headers")) {
         // ignore
       }  else if (arg.equals("-source")) {
         if (++nArg == args.length) {

--- a/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
+++ b/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
@@ -63,8 +63,8 @@ Other options:\n\
   -processor <class1>[,<class2>...] Names of the annotation processors to run; bypasses \
   \n                               default discovery process.\n\
   -processorpath <path>        Specify where to find annotation processors.\n\
-  --segmented-headers          Generates headers with guards around each declared type.\
-  \n                               Useful for breaking import cycles.\n\
+  --no-segmented-headers       Do not generate headers with guards around each declared\
+  \n                               type.\n\
   --static-accessor-methods    Generates accessor methods for static variables and\
   \n                               enum constants.\n\
   --strip-gwt-incompatible     Removes methods that are marked with a GwtIncompatible\

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCSegmentedHeaderGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCSegmentedHeaderGeneratorTest.java
@@ -30,7 +30,7 @@ public class ObjectiveCSegmentedHeaderGeneratorTest extends GenerationTest {
   @Override
   protected void setUp() throws IOException {
     super.setUp();
-    Options.enableSegmentedHeaders();
+    // Segmented headers are on by default.
   }
 
   public void testTypicalPreprocessorStatements() throws IOException {

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCSegmentedHeaderGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/ObjectiveCSegmentedHeaderGeneratorTest.java
@@ -27,11 +27,7 @@ import java.io.IOException;
  */
 public class ObjectiveCSegmentedHeaderGeneratorTest extends GenerationTest {
 
-  @Override
-  protected void setUp() throws IOException {
-    super.setUp();
-    // Segmented headers are on by default.
-  }
+  // Segmented headers are on by default.
 
   public void testTypicalPreprocessorStatements() throws IOException {
     String translation = translateSourceFile(


### PR DESCRIPTION
Adds the flag --no-segmented-headers to disable the feature.
Ignore and accept the old --segmented-headers flag.

Per https://groups.google.com/d/msg/j2objc-discuss/Db3YUD9V0TY/C4HYerpQAwAJ