### PR TITLE
Eliminate inner class constructors correctly when ProGuard explicitly instructs so

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/DeadCodeEliminator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/DeadCodeEliminator.java
@@ -155,7 +155,7 @@ public class DeadCodeEliminator extends TreeVisitor {
         }
         IMethodBinding binding = method.getMethodBinding();
         String name = getProGuardName(binding);
-        String signature = BindingUtil.getSignature(binding);
+        String signature = BindingUtil.getProGuardSignature(binding);
         if (deadCodeMap.isDeadMethod(clazz, name, signature)) {
           if (method.isConstructor()) {
             deadCodeMap.addConstructorRemovedClass(clazz);

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/DeadCodeEliminatorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/DeadCodeEliminatorTest.java
@@ -222,4 +222,32 @@ public class DeadCodeEliminatorTest extends GenerationTest {
     assertTranslation(translation, "Foo_Baz_init");
     assertNotInTranslation(translation, "- (void)g");
   }
+
+  public void testDeadClass_DeadInnerClassConstructor() throws IOException {
+    DeadCodeMap map = DeadCodeMap.builder()
+        .addDeadField("Foo$A", "z")
+        .addDeadField("Foo$A", "this$0")
+        .addDeadMethod("Foo$A", "Foo$A", "(LFoo;I)V")
+        .addDeadMethod("Foo$A", "f", "()I")
+        .build();
+    setDeadCodeMap(map);
+    String source = "public class Foo {\n"
+        + "  int y;\n"
+        + "  public Foo(int x) { y = x; }\n"
+        + "\n"
+        + "  class A {\n"
+        + "    int z;\n"
+        + "    A(int x) { z = x; }\n"
+        + "    int f() { return z + y; }\n"
+        + "  }\n"
+        + "}\n";
+    String translation = translateSourceFile(source, "Foo", "Foo.h");
+    assertTranslation(translation, "@interface Foo_A");
+    assertNotInTranslation(translation, "z_;");
+    translation = getTranslatedFile("Foo.m");
+    assertNotInTranslation(translation, "Foo *this$0_;");
+    assertNotInTranslation(translation, "JreStrongAssign(&self->this$0_, outer$");
+    assertNotInTranslation(translation, "self->z_ = x;");
+    assertNotInTranslation(translation, "- (jint)f");
+  }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/DeadCodeEliminatorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/DeadCodeEliminatorTest.java
@@ -69,7 +69,7 @@ public class DeadCodeEliminatorTest extends GenerationTest {
         + "  }\n"
         + "}\n";
     DeadCodeMap map = DeadCodeMap.builder()
-        .addDeadMethod("A$B", "A$B", "(I)V")
+        .addDeadMethod("A$B", "A$B", "(LA;I)V")
         .build();
     setDeadCodeMap(map);
     String translation = translateSourceFile(source, "A", "A.m");


### PR DESCRIPTION
This fixes #654 by adding a new `getProGuardSignature` method to `BindingUtil` so that the dead code eliminator can use the correct signature to match against the dead code report. As mentioned in #654, the signature was not correct because dead code elimination is the first pass in the translation processor, before inner class methods are furnished with outer types in a later pass.

Since `InitializationNormalizer` needs the dead code map to work correctly, I wonder if dead code elimination should be done after `InnerClassExtractor` is finished, but I'm not sure if the pass will still work after the nodes have been modified by the other passes. The downside of the approach here is one more special case in `BindingUtil`, though I believe it's straightforward enough for the job.

This also fixes [a previous test case](https://github.com/lukhnos/j2objc/commit/0024184c7ea56c399149974c2f732b5a2641557f), as I don't think ProGuard produces the same signature.
