### PR TITLE
Upgrade Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_script:
   - scripts/osx-set-java.sh
 
 # Travis-CI kills the build after 50 minutes, so break it up into
-# smaller commands.
-script: make -j4 dist
+# smaller commands and only bulid two archs.
+script: J2OBJC_ARCHS="macosx iphone" make -j4 dist
 after_script:
   - make test_translator
   - make test_cycle_finder

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # j2objc is a mixed-language project, but setting objective-c forces the OS to OSX.
 language: objective-c
 os: osx
+osx_image: xcode7.1
 
 env:
   - LATEST_JAVA=true

--- a/scripts/osx-set-java.sh
+++ b/scripts/osx-set-java.sh
@@ -4,6 +4,5 @@
 
 if $LATEST_JAVA; then
   brew update
-  brew install caskroom/cask/brew-cask
   brew cask install java
 fi


### PR DESCRIPTION
The Travis CI jobs of my fork was reporting the following errors: [this job](https://travis-ci.org/lukhnos/j2objc/jobs/95389403) failed because Travis CI's default OS X image was still on Xcode 6.1, then after upgrading the setting [this job](https://travis-ci.org/lukhnos/j2objc/jobs/95399149) failed because it appears that `brew-cask` has now been part of the recent OS X images.

After those changes it now builds, but [this job](https://travis-ci.org/lukhnos/j2objc/jobs/95404176) didn't finish because it exceeded the maximum 50 minutes that Travis allows. Perhaps we could disable `make dist` for now and only run the tests?
