### PR TITLE
Fix cyclic reference leaks in ReferenceQueue

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/lang/ref/ReferenceQueue.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/lang/ref/ReferenceQueue.java
@@ -29,6 +29,9 @@ public class ReferenceQueue<T> {
 
     private Reference<? extends T> head;
 
+    // j2objc: Use a sentinel to avoid the "reference.queueNext = reference" leak.
+    private final Reference<? extends T> SENTINEL = new WeakReference<>(null, null);
+
     /**
      * Constructs a new instance of this class.
      */
@@ -52,7 +55,7 @@ public class ReferenceQueue<T> {
 
         ret = head;
 
-        if (head == head.queueNext) {
+        if (SENTINEL == head.queueNext) {
             head = null;
         } else {
             head = head.queueNext;
@@ -134,7 +137,7 @@ public class ReferenceQueue<T> {
      */
     synchronized void enqueue(Reference<? extends T> reference) {
         if (head == null) {
-            reference.queueNext = reference;
+            reference.queueNext = SENTINEL;
         } else {
             reference.queueNext = head;
         }


### PR DESCRIPTION
This fixes #675 by using a sentinel object to mark that a `Reference` is the only entry in the queue. I followed @kstanger's [previous fix for ConcurrentLinkedQueue](https://github.com/google/j2objc/commit/db2597b64e3cd8ce18a6d8832df08b35a7a7b529) for the naming convention.

After this I no longer see the leaks in [my test case](https://gist.github.com/lukhnos/f628a45939cba16d3f11), and an app of mine that uses a lot of `WeakHashMap` no longer leaks.

One thing I don't fully understand is under which condition a `ReferenceQueue` may still have entries not removed by `poll()` (and therefore it leaves to the translated queue's `-dealloc` to clean up the `head`) , but I'm definitely interested in using this chance to learn more about J2ObjC's weak-referencing mechanism.