### PR TITLE
Search for resource in [NSBundle allFrameworks]

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/lang/ClassLoader.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/lang/ClassLoader.java
@@ -717,6 +717,12 @@ class SystemClassLoader extends ClassLoader {
         [urls addWithId:JavaNetNetFactory_newURLWithNSString_([nativeURL description])];
       }
     }
+    for (NSBundle *bundle in [NSBundle allFrameworks]) {
+      NSURL *nativeURL = [bundle URLForResource:name withExtension:nil];
+      if (nativeURL) {
+        [urls addWithId:JavaNetNetFactory_newURLWithNSString_([nativeURL description])];
+      }
+    }
     return JavaUtilCollections_enumerationWithJavaUtilCollection_(urls);
   ]-*/;
 


### PR DESCRIPTION
This implements #678. Previously `ClassLoader.findResources` finds resource in `[NSBundle allBundles]`, which are non-framework bundles. With `[NSBundle allFrameworks]` we enable the use of dynamic frameworks.

One caveat though is that this now searches many more bundles. If we log the method, it'll look something like this:

```
finding: some/resource/path/file.ext

searching in non-framework bundle: org.lukhnos.MyApp
searching in non-framework bundle: com.apple.uikit.Artwork

searching in framework bundle: com.apple.Foundation
searching in framework bundle: com.apple.AddressBook
searching in framework bundle: com.apple.iphonesimulator.SimulatorClient
searching in framework bundle: (null)
searching in framework bundle: com.apple.BackBoardServices
searching in framework bundle: com.apple.Accelerate.vecLib
searching in framework bundle: com.apple.ProofReader
searching in framework bundle: com.apple.BaseBoard
searching in framework bundle: com.apple.opengles
searching in framework bundle: com.apple.FontServices
searching in framework bundle: com.apple.AddressBook.ContactsFoundation
searching in framework bundle: com.apple.DTDDISupport
searching in framework bundle: com.apple.contacts.vCard
searching in framework bundle: com.apple.IntlPreferences
searching in framework bundle: com.apple.UIKit
searching in framework bundle: com.apple.GraphicsServices
searching in framework bundle: com.apple.MobileAssets
searching in framework bundle: com.apple.CoreImage
searching in framework bundle: com.apple.UserNotificationServices
searching in framework bundle: com.apple.CoreUI
searching in framework bundle: com.apple.CoreFoundation
searching in framework bundle: com.apple.mobilespotlight.index
searching in framework bundle: com.apple.Accounts
searching in framework bundle: com.apple.JavaScriptCore
searching in framework bundle: com.apple.contacts.Contacts
searching in framework bundle: org.lukhnos.MyFramework
searching in framework bundle: com.apple.TextInput
searching in framework bundle: com.apple.vision.FaceCore
searching in framework bundle: com.apple.ConstantClasses
searching in framework bundle: com.apple.ParsecSubscriptionServiceSupport
searching in framework bundle: com.apple.QuartzCore
searching in framework bundle: com.apple.CoreMedia
searching in framework bundle: (null)
searching in framework bundle: com.apple.UIFoundation
searching in framework bundle: com.apple.CoreData.PersistenceTesting
searching in framework bundle: com.apple.AssertionServices
searching in framework bundle: com.apple.CFNetwork
searching in framework bundle: com.apple.CoreVideo
searching in framework bundle: (null)
searching in framework bundle: com.apple.FrontBoardServices
searching in framework bundle: com.apple.PhysicsKit
searching in framework bundle: com.apple.dataaccess.dataaccessexpress.framework
searching in framework bundle: com.apple.AppSupport
searching in framework bundle: com.apple.OAuth
searching in framework bundle: com.apple.MobileCoreServices
searching in framework bundle: com.apple.audio.toolbox.AudioToolbox
searching in framework bundle: com.apple.WebCore
searching in framework bundle: com.apple.pluginkit.framework
searching in framework bundle: com.apple.DictionaryServices
searching in framework bundle: com.apple.SpringBoardServices
searching in framework bundle: com.apple.CoreSpotlight
searching in framework bundle: com.apple.AggregateDictionary
searching in framework bundle: com.apple.LanguageModeling
searching in framework bundle: (null)
searching in framework bundle: com.apple.CoreText
searching in framework bundle: com.apple.WebKitLegacy
```

In total, 56 framework bundles are searched. There are four bundles without an identifier. Logging the fetched `NSBundle`, and they are (I've shortened the paths):

```
NSBundle <$SDKROOT/usr/lib/system> (loaded)
NSBundle <$APP_SANDBOX_ROOT/data/Containers/Bundle/Application/4FBC94FD-6055-410D-B133-A4A32BD63C8D/MyApp.app/Frameworks> (loaded)
NSBundle <$SDKROOT/usr/lib> (loaded)
NSBundle <$SDKROOT/usr/lib/system/introspection> (loaded)
```

So my question would be whether this would be a problem for apps that load a lot of resources this way – I assume not, but then again the library I'm translating that uses SPI only loads a very small number of files from `META-INF`. The performance cost is therefore minimal for my use case, and I use Android's and iOS's platform-specific resource loaders for app-specific and UI resources.
