### PR TITLE
fixing head to build with public xmlpull headers

### DIFF
--- a/jre_emul/Makefile
+++ b/jre_emul/Makefile
@@ -206,8 +206,8 @@ dist_includes: $(BUILD_DIR)/.jre_dist_includes
 $(BUILD_DIR)/.jre_dist_includes: $(PUBLIC_TRANSLATED_HEADERS:%=$(GEN_OBJC_DIR)/%) \
     $(PUBLIC_EMULATION_HEADERS:%=$(EMULATION_CLASS_DIR)/%) | $(DIST_INCLUDE_DIR)
 	@echo copying jre_emul header files
-	@(cd $(EMULATION_CLASS_DIR) && tar cf - \
-	    $(PUBLIC_EMULATION_HEADERS:$(EMULATION_CLASS_DIR)/%=%)) \
+	@cd $(EMULATION_CLASS_DIR) && tar cf - \
+	    $(PUBLIC_EMULATION_HEADERS:$(EMULATION_CLASS_DIR)/%=%) \
 	    | (cd $(DIST_INCLUDE_DIR); tar xfp -)
 	@(cd $(GEN_OBJC_DIR) && tar cf - \
 	    $(PUBLIC_TRANSLATED_HEADERS:$(GEN_OBJC_DIR)/%=%)) \

--- a/jre_emul/java_sources.mk
+++ b/jre_emul/java_sources.mk
@@ -1110,7 +1110,12 @@ JAVA_PUBLIC_SOURCES_XML = \
   org/xml/sax/helpers/ParserFactory.java \
   org/xml/sax/helpers/XMLFilterImpl.java \
   org/xml/sax/helpers/XMLReaderAdapter.java \
-  org/xml/sax/helpers/XMLReaderFactory.java
+  org/xml/sax/helpers/XMLReaderFactory.java \
+  org/xmlpull/v1/XmlPullParser.java \
+  org/xmlpull/v1/XmlPullParserException.java \
+  org/xmlpull/v1/XmlPullParserFactory.java \
+  org/xmlpull/v1/XmlSerializer.java \
+  org/xmlpull/v1/sax2/Driver.java
 
 JAVA_PRIVATE_SOURCES_XML = \
   libcore/internal/StringPool.java \
@@ -1139,12 +1144,7 @@ JAVA_PRIVATE_SOURCES_XML = \
   org/apache/harmony/xml/parsers/SAXParserFactoryImpl.java \
   org/apache/harmony/xml/parsers/SAXParserImpl.java \
   org/kxml2/io/KXmlParser.java \
-  org/kxml2/io/KXmlSerializer.java \
-  org/xmlpull/v1/XmlPullParser.java \
-  org/xmlpull/v1/XmlPullParserException.java \
-  org/xmlpull/v1/XmlPullParserFactory.java \
-  org/xmlpull/v1/XmlSerializer.java \
-  org/xmlpull/v1/sax2/Driver.java
+  org/kxml2/io/KXmlSerializer.java
 
 JAVA_PUBLIC_SOURCES_ZIP = \
   java/util/jar/Attributes.java \


### PR DESCRIPTION
XMLPull headers should be public (actually, most of these private headers should be).  I'm not sure of the advantage of hiding headers to statically linked classes.  Making them private just ensures that no one can use them (not even linking in their own transpiled then compiled versions).

Also, I had to take the translated headers copying out of a subshell to get "make dist" to work.  It seems that there is some sort of race condition.