### PR TITLE
Fixes a number of retain cycles and exceptions

### DIFF
--- a/jre_emul/android/libcore/luni/src/main/java/java/util/PropertyResourceBundle.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/PropertyResourceBundle.java
@@ -19,7 +19,10 @@ package java.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import static java.nio.charset.Charsets.UTF_8;
+import libcore.io.IoUtils;
 
 /**
  * {@code PropertyResourceBundle} loads resources from an {@code InputStream}. All resources are
@@ -33,6 +36,99 @@ import java.io.Reader;
 public class PropertyResourceBundle extends ResourceBundle {
 
     Properties resources;
+
+    /**
+     * Finds the named resource bundle for the default {@code Locale} and the caller's
+     * {@code ClassLoader}.
+     *
+     * @param bundleName
+     *            the name of the {@code ResourceBundle}.
+     * @return the requested {@code ResourceBundle}.
+     * @throws MissingResourceException
+     *                if the {@code ResourceBundle} cannot be found.
+     */
+    public static ResourceBundle getBundle(String bundleName) throws MissingResourceException {
+        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        if (classLoader == null) {
+            classLoader = getLoader();
+        }
+        return getBundle(bundleName, Locale.getDefault(), classLoader);
+    }
+
+    /**
+     * Finds the named resource bundle for the specified {@code Locale} and {@code ClassLoader}.
+     *
+     * The passed base name and {@code Locale} are used to create resource bundle names.
+     * The first name is created by concatenating the base name with the result
+     * of {@link Locale#toString()}. From this name all parent bundle names are
+     * derived. Then the same thing is done for the default {@code Locale}. This results
+     * in a list of possible bundle names.
+     *
+     * <strong>Example</strong> For the basename "BaseName", the {@code Locale} of the
+     * German part of Switzerland (de_CH) and the default {@code Locale} en_US the list
+     * would look something like this:
+     *
+     * <ol>
+     * <li>BaseName_de_CH</li>
+     * <li>BaseName_de</li>
+     * <li>Basename_en_US</li>
+     * <li>Basename_en</li>
+     * <li>BaseName</li>
+     * </ol>
+     *
+     * This list also shows the order in which the bundles will be searched for a requested
+     * resource in the German part of Switzerland (de_CH).
+     *
+     * As a first step, this method tries to instantiate
+     * a {@code ResourceBundle} with the names provided.
+     * If such a class can be instantiated and initialized, it is returned and
+     * all the parent bundles are instantiated too. If no such class can be
+     * found this method tries to load a {@code .properties} file with the names by
+     * replacing dots in the base name with a slash and by appending
+     * "{@code .properties}" at the end of the string. If such a resource can be found
+     * by calling {@link ClassLoader#getResource(String)} it is used to
+     * initialize a {@link PropertyResourceBundle}. If this succeeds, it will
+     * also load the parents of this {@code ResourceBundle}.
+     *
+     * For compatibility with older code, the bundle name isn't required to be
+     * a fully qualified class name. It's also possible to directly pass
+     * the path to a properties file (without a file extension).
+     *
+     * @param bundleName
+     *            the name of the {@code ResourceBundle}.
+     * @param locale
+     *            the {@code Locale}.
+     * @param loader
+     *            the {@code ClassLoader} to use.
+     * @return the requested {@code ResourceBundle}.
+     * @throws MissingResourceException
+     *                if the {@code ResourceBundle} cannot be found.
+     */
+    public static ResourceBundle getBundle(String bundleName, Locale locale,
+                                           ClassLoader loader) throws MissingResourceException {
+        if (loader == null) {
+            throw new NullPointerException("loader == null");
+        } else if (bundleName == null) {
+            throw new NullPointerException("bundleName == null");
+        }
+        Locale defaultLocale = Locale.getDefault();
+        if (!cacheLocale.equals(defaultLocale)) {
+            cache.clear();
+            cacheLocale = defaultLocale;
+        }
+        ResourceBundle bundle = null;
+        if (!locale.equals(defaultLocale)) {
+            bundle = handleGetBundle(false, bundleName, locale, loader);
+        }
+        if (bundle == null) {
+            bundle = handleGetBundle(true, bundleName, defaultLocale, loader);
+            if (bundle == null) {
+                throw missingResourceException(bundleName + '_' + locale, "");
+            }
+        }
+        return bundle;
+    }
+
 
     /**
      * Constructs a new instance of {@code PropertyResourceBundle} and loads the
@@ -64,6 +160,76 @@ public class PropertyResourceBundle extends ResourceBundle {
         resources.load(reader);
     }
 
+    /**
+     *  We know the bundle should be a properties file since this is the PropertyResourceBundle class,
+     *  not the PropertyResourceBundle class, so here we override handleGetBundle that we won't
+     *  bother trying to load as a class first, needlessly throwing exceptions every time we
+     *  intend to open a .properties file.
+     */
+    private static ResourceBundle handleGetBundle(boolean loadBase, String base, Locale locale,
+                                                  ClassLoader loader) {
+        String localeName = locale.toString();
+        String bundleName = localeName.isEmpty()
+                ? base
+                : (base + "_" + localeName);
+        Object cacheKey = loader != null ? loader : "null";
+        Hashtable<String, ResourceBundle> loaderCache = getLoaderCache(cacheKey);
+        ResourceBundle cached = loaderCache.get(bundleName);
+        if (cached != null) {
+            if (cached == MISSINGBASE) {
+                return null;
+            } else if (cached == MISSING) {
+                if (!loadBase) {
+                    return null;
+                }
+                Locale newLocale = strip(locale);
+                if (newLocale == null) {
+                    return null;
+                }
+                return handleGetBundle(loadBase, base, newLocale, loader);
+            }
+            return cached;
+        }
+
+        ResourceBundle bundle = null;
+
+        String fileName = bundleName.replace('.', '/') + ".properties";
+        InputStream stream = loader != null
+                ? loader.getResourceAsStream(fileName)
+                : ClassLoader.getSystemResourceAsStream(fileName);
+        if (stream != null) {
+            try {
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, UTF_8));
+                bundle.setLocale(locale);
+            } catch (IOException ignored) {
+            } finally {
+                IoUtils.closeQuietly(stream);
+            }
+        }
+
+        Locale strippedLocale = strip(locale);
+        if (bundle != null) {
+            if (strippedLocale != null) {
+                ResourceBundle parent = handleGetBundle(loadBase, base, strippedLocale, loader);
+                if (parent != null) {
+                    bundle.setParent(parent);
+                }
+            }
+            loaderCache.put(bundleName, bundle);
+            return bundle;
+        }
+
+        if (strippedLocale != null && (loadBase || !strippedLocale.toString().isEmpty())) {
+            bundle = handleGetBundle(loadBase, base, strippedLocale, loader);
+            if (bundle != null) {
+                loaderCache.put(bundleName, bundle);
+                return bundle;
+            }
+        }
+        loaderCache.put(bundleName, loadBase ? MISSINGBASE : MISSING);
+        return null;
+    }
+    
     protected Set<String> handleKeySet(){
         return resources.stringPropertyNames();
     }

--- a/jre_emul/android/libcore/luni/src/main/java/java/util/ResourceBundle.java
+++ b/jre_emul/android/libcore/luni/src/main/java/java/util/ResourceBundle.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.nio.charset.Charsets;
 import static java.nio.charset.Charsets.UTF_8;
 import libcore.io.IoUtils;
+import java.util.PropertyResourceBundle;
 
 /**
  * {@code ResourceBundle} is an abstract class which is the superclass of classes which
@@ -105,14 +106,14 @@ public abstract class ResourceBundle {
         }
     }
 
-    private static final ResourceBundle MISSING = new MissingBundle();
+    public static final ResourceBundle MISSING = new MissingBundle();
 
-    private static final ResourceBundle MISSINGBASE = new MissingBundle();
+    public static final ResourceBundle MISSINGBASE = new MissingBundle();
 
-    private static final WeakHashMap<Object, Hashtable<String, ResourceBundle>> cache
+    public static final WeakHashMap<Object, Hashtable<String, ResourceBundle>> cache
             = new WeakHashMap<Object, Hashtable<String, ResourceBundle>>();
 
-    private static Locale cacheLocale = Locale.getDefault();
+    public static Locale cacheLocale = Locale.getDefault();
 
     /**
      * Constructs a new instance of this class.
@@ -233,7 +234,7 @@ public abstract class ResourceBundle {
         return bundle;
     }
 
-    private static MissingResourceException missingResourceException(String className, String key) {
+    public static MissingResourceException missingResourceException(String className, String key) {
         String detail = "Can't find resource for bundle '" + className + "', key '" + key + "'";
         throw new MissingResourceException(detail, className, key);
     }
@@ -271,7 +272,7 @@ public abstract class ResourceBundle {
         return getBundle(baseName, targetLocale, getLoader(), control);
     }
 
-    private static ClassLoader getLoader() {
+    public static ClassLoader getLoader() {
         ClassLoader cl = ResourceBundle.class.getClassLoader();
         if (cl == null) {
             cl = ClassLoader.getSystemClassLoader();
@@ -549,7 +550,7 @@ public abstract class ResourceBundle {
         return null;
     }
 
-    private static Hashtable<String, ResourceBundle> getLoaderCache(Object cacheKey) {
+    public static Hashtable<String, ResourceBundle> getLoaderCache(Object cacheKey) {
         synchronized (cache) {
             Hashtable<String, ResourceBundle> loaderCache = cache.get(cacheKey);
             if (loaderCache == null) {
@@ -585,7 +586,7 @@ public abstract class ResourceBundle {
      * Returns a locale with the most-specific field removed, or null if this
      * locale had an empty language, country and variant.
      */
-    private static Locale strip(Locale locale) {
+    public static Locale strip(Locale locale) {
         String language = locale.getLanguage();
         String country = locale.getCountry();
         String variant = locale.getVariant();
@@ -601,7 +602,7 @@ public abstract class ResourceBundle {
         return new Locale(language, country, variant);
     }
 
-    private void setLocale(Locale locale) {
+    public void setLocale(Locale locale) {
         this.locale = locale;
     }
 

--- a/make/j2objc_deps.mk
+++ b/make/j2objc_deps.mk
@@ -88,10 +88,10 @@ protobuf_runtime_java: protobuf_compiler_dist
 protobuf_runtime_dist: jre_emul_dist protobuf_compiler_dist
 	@$(MAKE) -C $(J2OBJC_ROOT)/protobuf/runtime dist
 
-xalan_dist: translator_dist jre_emul_dist
+xalan_dist: annotations_dist translator_dist jre_emul_dist
 	@$(MAKE) -C $(J2OBJC_ROOT)/xalan dist
 
-xalan_java: java_deps_dist jre_emul_jar_dist
+xalan_java: annotations_dist java_deps_dist jre_emul_jar_dist
 	@$(MAKE) -C $(J2OBJC_ROOT)/xalan java
 
 

--- a/xalan/Makefile
+++ b/xalan/Makefile
@@ -31,7 +31,7 @@ J2OBJCC := $(ARCH_BIN_DIR)/j2objcc -c $(INCLUDE_DIRS:%=-I%)
 TRANSLATE_JAVA_FULL = $(JAVA_SOURCES)
 TRANSLATE_JAVA_RELATIVE = $(JAVA_SOURCES:$(SRC_DIR)/%=%)
 TRANSLATE_ARGS = -q --batch-translate-max=300 \
-    -sourcepath $(SOURCEPATH) -encoding UTF-8 -J-Xmx2G
+    -sourcepath $(SOURCEPATH) -classpath $(DIST_JAR_DIR)/j2objc_annotations.jar -encoding UTF-8 -J-Xmx2G
 include $(J2OBJC_ROOT)/make/translate.mk
 
 FAT_LIB_NAME = xalan
@@ -82,7 +82,7 @@ java: $(DIST_JAR)
 $(JAR): $(JAVA_SOURCES) | $(BUILD_DIR) java_deps_dist annotations_dist
 	@echo "building j2objc_xalan.jar"
 	@stage_dir=`mktemp -d -t j2objc-xalan`; \
-	$(JAVAC) -sourcepath $(SOURCEPATH) -encoding UTF-8 \
+	$(JAVAC) -sourcepath $(SOURCEPATH) -classpath $(DIST_JAR_DIR)/j2objc_annotations.jar -encoding UTF-8 \
 	    -d $$stage_dir -source 1.7 -target 1.7 -bootclasspath $(DIST_JAR_DIR)/jre_emul.jar $^; \
 	jar cf $@ -C $$stage_dir .; \
 	rm -rf $$stage_dir
@@ -113,6 +113,6 @@ objc_sources_manifest: $(OBJC_SOURCES_MANIFEST)
 	@:
 
 find_cycles: $(JAVA_SOURCES_MANIFEST) | cycle_finder_dist jre_emul_java_manifest
-	$(DIST_DIR)/cycle_finder -sourcepath $(SOURCEPATH) \
+	$(DIST_DIR)/cycle_finder -sourcepath $(SOURCEPATH) -classpath $(DIST_JAR_DIR)/j2objc_annotations.jar \
 	  -w ../jre_emul/cycle_whitelist.txt -w cycle_whitelist \
 	  -s ../jre_emul/$(BUILD_DIR_NAME)/java_sources.mf -s $(JAVA_SOURCES_MANIFEST)

--- a/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xalan/transformer/TransformerIdentityImpl.java
+++ b/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xalan/transformer/TransformerIdentityImpl.java
@@ -66,6 +66,8 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.ext.DeclHandler;
 import org.xml.sax.ext.LexicalHandler;
 
+import com.google.j2objc.annotations.Weak;
+
 /**
  * This class implements an identity transformer for
  * {@link javax.xml.transform.sax.SAXTransformerFactory#newTransformerHandler()}
@@ -1440,6 +1442,7 @@ public class TransformerIdentityImpl extends Transformer
   private DeclHandler m_resultDeclHandler;
 
   /** The Serializer, which may or may not be null. */
+  @Weak
   private Serializer m_serializer;
 
   /** The Result object. */

--- a/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
+++ b/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xalan/transformer/TransformerImpl.java
@@ -94,6 +94,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.ext.LexicalHandler;
+import com.google.j2objc.annotations.Weak;
 
 /**
  * This class implements the
@@ -123,6 +124,7 @@ public class TransformerImpl extends Transformer
   private String m_urlOfSource = null;
 
   /** The Result object at the start of the transform, if any. */
+  @Weak
   private Result m_outputTarget = null;
 
   /**

--- a/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/ElemContext.java
+++ b/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/ElemContext.java
@@ -19,6 +19,7 @@
  * $Id: ElemContext.java 468654 2006-10-28 07:09:23Z minchau $
  */
 package org.apache.xml.serializer;
+import com.google.j2objc.annotations.Weak;
 
 /**
  * This class is a stack frame that consists of 
@@ -106,6 +107,7 @@ final class ElemContext
     private ElemContext m_next;
 
     /** The previous element "stack frame". */
+    @Weak
     final ElemContext m_prev;
 
     /**

--- a/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/Encodings.java
+++ b/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/Encodings.java
@@ -353,13 +353,25 @@ public final class Encodings extends Object
                 }
                 else
                 {
-                    try {
-                        // Get the substring after the Mime names
-                        final String highVal = val.substring(len).trim();
-                        highChar = (char) Integer.decode(highVal).intValue();
-                    }
-                    catch( NumberFormatException e) {
+                    // Get the substring after the Mime names
+                    final String highVal = val.substring(len).trim();
+
+                    // Check obvious wrong values first to avoid throwing exceptions in normal cases;
+                    // we expect to sometimes get an empty string.
+                    if(highVal == null) {
                         highChar = 0;
+                    }
+                    else if(highVal.isEmpty()) {
+                        highChar = 0;
+                    }
+                    // Only throw an exception in unusual cases.
+                    else {
+                        try {
+                            highChar = (char) Integer.decode(highVal).intValue();
+                        }
+                        catch( NumberFormatException e) {
+                            highChar = 0;
+                        }
                     }
                     String mimeNames = val.substring(0, len);
                     StringTokenizer st =

--- a/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/NamespaceMappings.java
+++ b/xalan/third_party/android/platform/external/apache-xml/src/main/java/org/apache/xml/serializer/NamespaceMappings.java
@@ -25,6 +25,7 @@ import java.util.Hashtable;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+import com.google.j2objc.annotations.Weak;
 
 /**
  * This class keeps track of the currently defined namespaces. Conceptually the
@@ -77,6 +78,7 @@ public class NamespaceMappings
      * mappings at deeper depths push later on such a stack.  Mappings pushed
      * earlier on the stack will have smaller values for MappingRecord.m_declarationDepth.
      */
+    @Weak
     private Hashtable m_namespaces = new Hashtable();
 
     /** 
@@ -92,6 +94,7 @@ public class NamespaceMappings
      * removed at the same time by using this stack to
      * ensure prefix/uri map scopes are closed correctly.
      */
+    @Weak
     private Stack m_nodeStack = new Stack();
 
     private static final String EMPTYSTRING = "";


### PR DESCRIPTION
I have fixed the leaks. Most were from retain cycles, the rest from exceptions.
## Explanation of the retain cycles leaks

TransformerImpl - m_outputTarget is passed as an argument into a function and is owned by the caller, yet was being assigned to a strong instance variable of the callee. I set it to weak.

TransformerIdentityImpl - m_serializer gets set to a property of a property of a property of an argument passed to the caller from the callee. Should not be owned by callee. I set it to weak.

ElemContext - m_next is pretty clearly a cyclical reference, as Keith already noted in an e-mail. I set it to weak.

NamespaceMappings - m_namespaces and m_nodeStack are both collections that will end up containing things that are already owned elsewhere. I would think that resetting the Transformer should clear these, but I tried it, and that did not free up the memory or fix the leak. So, I set these to weak, and it fixed the leak without seeming to have any negative effects. 
## Examples of leaks from Exceptions

( 1 )

For example in the translated Encodings.m: 

```
@try {
NSString *highVal = [((NSString *) nil_chk([((NSString *) nil_chk(val)) substring:len])) trim];
highChar = (jchar) [((JavaLangInteger *) nil_chk(JavaLangInteger_decodeWithNSString_(highVal))) intValue];
}
@catch ... (throw an exception and set highChar = 0)
```

If highVal comes in as an empty string (this happens often), then an exception gets thrown. Memory leak. 

So I had to go in by hand and change it to:

```
         NSString *highVal = [((NSString *) nil_chk([((NSString *) nil_chk(val)) substring:len])) trim];
         if(highVal == nil) {
            highChar = 0;
          }
          else if([highVal isEqualToString:@""]) {
            highChar = 0;
          }
          else {
              @try {
                   highChar = (jchar) [((JavaLangInteger *) nil_chk(JavaLangInteger_decodeWithNSString_(highVal))) intValue];
               }
              @catch ... (throw an exception and set highChar = 0)
          }
```

**Solution**: Now that I know that works I have modified Java source to affect the same result (check for a null or empty string first before getting draconian with exceptions). 

( 2 )

In another case, I was seeing this call tree leading to an exception being thrown:

OrgApacheXmlSerializerCharInfo_initWithNSString_withNSString_withBoolean_ ---->
JavaUtilResourceBundle_getBundleWithNSString_withJavaUtilLocale_withJavaLangClassLoader_   ---->
JavaUtilResourceBundle_handleGetBundleWithBoolean_withNSString_withJavaUtilLocale_withJavaLangClassLoader_ ---->
JavaUtilResourceBundle_handleGetBundleWithBoolean_withNSString_withJavaUtilLocale_withJavaLangClassLoader_ ---->
IOSClass_forName_ ---->
[JavaLangClassNotFoundException initWithNSString:]

So I put in some debug code into JavaUtilResourceBundle to NSLog the name of the class that it was not finding. Here are the three classes it could not find:

org.apache.xml.serializer.XMLEntities_en_US
org.apache.xml.serializer.XMLEntities_en
org.apache.xml.serializer.XMLEntities

**Explanation**: 
These are not actually classes. Xalan's apache.xml.serializer.CharInfo (l. 194) actually calls getBundle on java.util.PropertyResourceBundle. But PropertyResourceBundle does not implement that method, so we use its super-class, ResourceBundle's static methods to try to find a resource called "XMLEntities.properties". 

However, when ResourceBundle's handleGetBundle runs, the first thing it tries to do is append a locale string to the end, then try to load that as a class. That throws an exception of course. Then it strips off "_US" and tries to load the remaining string again as a class. That throws an exception as well. Then it strips off "_en" and tries to load that as a class. That also throws an exception.

Only after throwing these there exceptions does it finally get around to adding ".properties" onto the end, and trying to load that.

Why are we even trying to load it as a class here? We shouldn't be; we knew it was a .properties file from the beginning. After all, the only really good reason to subclass ResourceBundle as PropertyResourceBundle would be precisely to not do try to load it as a class first since we already know it's a .properties file. 

**Solution**:
I added to PropertyResourceBundle its own static methods getBundle and handleGetBundle to that hide the abstract superclass versions, and implement the proper behavior (load as a .properties file always, and never try to load as a class). 
