### PR TITLE
Fix a memory leak in Throwable constructor

### DIFF
--- a/jre_emul/Classes/NSException+JavaThrowable.m
+++ b/jre_emul/Classes/NSException+JavaThrowable.m
@@ -471,6 +471,7 @@ void NSException_initWithNSString_withNSException_withBoolean_withBoolean_(
   if (enableSuppression) {
     JavaUtilArrayList *newArray = new_JavaUtilArrayList_init();
     SetSuppressedExceptions(self, newArray);
+    [newArray release];
   }
   if (writeableStackTrace) {
     SetRawStack(self);


### PR DESCRIPTION
Simple fix for the Throwable constructor defined in `NSException+JavaThrowable.m` leaking the suppressedExceptions array.