### PR TITLE
Apple TV support +  OS X target to 10.7

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -42,6 +42,11 @@ ARCH_BUILD_MACOSX_DIR = $(ARCH_BUILD_DIR)/macosx
 ARCH_LIB_MACOSX_DIR = $(ARCH_LIB_DIR)/macosx
 DIST_LIB_MACOSX_DIR = $(DIST_LIB_DIR)/macosx
 
+# Appletv library dirs.
+ARCH_BUILD_TV_DIR = $(ARCH_BUILD_DIR)/appletvos
+ARCH_LIB_TV_DIR = $(ARCH_LIB_DIR)/appletvos
+DIST_LIB_TV_DIR = $(DIST_LIB_DIR)/appletvos
+
 ifndef GEN_OBJC_DIR
 GEN_OBJC_DIR = $(BUILD_DIR)/objc
 endif
@@ -50,7 +55,7 @@ GEN_JAVA_DIR = $(BUILD_DIR)/java
 endif
 
 ifndef J2OBJC_ARCHS
-J2OBJC_ARCHS = macosx iphone iphone64 watchv7k simulator simulator64
+J2OBJC_ARCHS = macosx iphone iphone64 watchv7k simulator simulator64 appletvos appletvsimulator
 endif
 
 # xcrun finds a specified tool in the current SDK /usr/bin directory.

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -20,6 +20,8 @@ FAT_LIB_MACOSX_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh)
 FAT_LIB_IPHONE_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --iphoneos)
 FAT_LIB_SIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --iphonesimulator)
 FAT_LIB_WATCH_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --watchos)
+FAT_LIB_TV_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvos)
+FAT_LIB_TVSIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvsimulator)
 
 FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -DJ2OBJC_BUILD_ARCH=x86_64 \
   -isysroot $(FAT_LIB_MACOSX_SDK_DIR)
@@ -34,6 +36,12 @@ FAT_LIB_SIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -miphoneos-version
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 FAT_LIB_SIMULATOR64_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
+
+FAT_LIB_TV_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -mappletvos-version-min=9.0 \
+  -isysroot $(FAT_LIB_TV_SDK_DIR)
+FAT_LIB_TVSIMULATOR_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -mappletvos-version-min=9.0 \
+  -isysroot $(FAT_LIB_TVSIMULATOR_SDK_DIR)
+
 FAT_LIB_XCODE_FLAGS = -arch $(1) -DJ2OBJC_BUILD_ARCH=$(1) -miphoneos-version-min=5.0 \
   -isysroot $(SDKROOT)
 
@@ -42,6 +50,7 @@ ifeq ("$(XCODE_7_MINIMUM)", "YES")
 FAT_LIB_IPHONE_FLAGS += -fembed-bitcode
 FAT_LIB_IPHONE64_FLAGS += -fembed-bitcode
 FAT_LIB_WATCHV7K_FLAGS += -fembed-bitcode
+FAT_LIB_TV_FLAGS += -fembed-bitcode
 endif
 
 # Command-line pattern for calling libtool and filtering the "same member name"
@@ -55,7 +64,9 @@ arch_flags = $(strip \
   $(patsubst iphone64,$(FAT_LIB_IPHONE64_FLAGS),\
   $(patsubst watchv7k,$(FAT_LIB_WATCHV7K_FLAGS),\
   $(patsubst simulator,$(FAT_LIB_SIMULATOR_FLAGS),\
-  $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),$(1))))))))
+  $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),\
+  $(patsubst appletvos,$(FAT_LIB_TV_FLAGS),\
+  $(patsubst appletvsimulator,$(FAT_LIB_TVSIMULATOR_FLAGS),$(1))))))))))
 
 fat_lib_dependencies:
 	@:
@@ -155,6 +166,16 @@ $(ARCH_BUILD_MACOSX_DIR)/lib$(1).a: $(BUILD_DIR)/objs-macosx/lib$(1).a
 	install -m 0644 $$< $$@
 endef
 
+# Generate the rule for the appletv library
+# Args:
+#   1. Library name.
+#   2. List of architecture specific libraries.
+define tv_lib_rule
+$(ARCH_BUILD_TV_DIR)/lib$(1).a: $(2)
+	@mkdir -p $$(@D)
+	$$(LIPO) -create $$^ -output $$@
+endef
+
 ifdef TARGET_TEMP_DIR
 # Targets specific to an xcode build
 
@@ -179,15 +200,19 @@ emit_arch_specific_compile_rules = $(foreach arch,$(XCODE_ARCHS),\
 else
 # Targets specific to a command-line build
 
-FAT_LIB_IOS_ARCHS = $(filter-out macosx,$(J2OBJC_ARCHS))
+FAT_LIB_IOS_ARCHS = $(filter-out macosx appletv%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_ARCH = $(filter macosx,$(J2OBJC_ARCHS))
+FAT_LIB_TV_ARCHS = $(filter appletv%,$(J2OBJC_ARCHS))
 
 emit_library_rules = $(foreach arch,$(J2OBJC_ARCHS),\
   $(eval $(call arch_lib_rule,$(BUILD_DIR)/objs-$(arch),$(1),$(2)))) \
   $(if $(FAT_LIB_IOS_ARCHS),\
     $(eval $(call fat_lib_rule,$(1),$(FAT_LIB_IOS_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_DIR)/lib$(1).a,) \
-  $(if $(FAT_LIB_MAC_ARCH),$(eval $(call mac_lib_rule,$(1))) $(ARCH_BUILD_MACOSX_DIR)/lib$(1).a,)
+  $(if $(FAT_LIB_MAC_ARCH),$(eval $(call mac_lib_rule,$(1))) $(ARCH_BUILD_MACOSX_DIR)/lib$(1).a,) \
+  $(if $(FAT_LIB_TV_ARCHS),\
+    $(eval $(call tv_lib_rule,$(1),$(FAT_LIB_TV_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
+    $(ARCH_BUILD_TV_DIR)/lib$(1).a,) \
 
 emit_arch_specific_compile_rules = $(foreach arch,$(J2OBJC_ARCHS),\
   $(call emit_compile_rules_for_arch,$(1),$(BUILD_DIR)/objs-$(arch),$(2),$(3),\

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -23,7 +23,7 @@ FAT_LIB_WATCH_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --w
 FAT_LIB_TV_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvos)
 FAT_LIB_TVSIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvsimulator)
 
-FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -DJ2OBJC_BUILD_ARCH=x86_64 \
+FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -DJ2OBJC_BUILD_ARCH=x86_64 -mmacosx-version-min=10.7 \
   -isysroot $(FAT_LIB_MACOSX_SDK_DIR)
 
 FAT_LIB_IPHONE_FLAGS = -arch armv7 -DJ2OBJC_BUILD_ARCH=armv7 -miphoneos-version-min=5.0 \

--- a/scripts/sysroot_path.sh
+++ b/scripts/sysroot_path.sh
@@ -24,7 +24,9 @@ if [ $# -gt 0 ]; then
     --iphoneos ) SDK_TYPE=iPhoneOS ;;
     --iphonesimulator ) SDK_TYPE=iPhoneSimulator ;;
     --watchos ) SDK_TYPE=WatchOS ;;
-    * ) echo "usage: $0 [--iphoneos | --iphonesimulator | --watchos]" && exit 1 ;;
+    --appletvos ) SDK_TYPE=AppleTVOS ;;
+    --appletvsimulator ) SDK_TYPE=AppleTVSimulator ;;
+    * ) echo "usage: $0 [--iphoneos | --iphonesimulator | --watchos | --appletvos | --appletvsimulator]" && exit 1 ;;
   esac
 fi
 
@@ -61,6 +63,10 @@ if [ "x${SDK_PATH}" = "x" ]; then
     SDK_TYPE=iphonesimulator
   elif [ ${SDK_TYPE} == "watchos" ]; then
     SDK_TYPE=watchos
+  elif [ ${SDK_TYPE} == "appletvos" ]; then
+    SDK_TYPE=appletvos
+  elif [ ${SDK_TYPE} == "appletvsimulator" ]; then
+    SDK_TYPE=appletvsimulator
   else
     SDK_TYPE=macosx
   fi


### PR DESCRIPTION
This PR introduces support for tvOS (Apple TV):

* Two new architectures are added in the J2OBJC_ARCHS: appletvos and appletvsimulator.
* A new output dir. is added, to contain binaries for tvOS builds. This dir. is handled similarly to the OS X case.

Additionally, this PR sets a target for OS X to 10.7, roughly equivalent (in terms of APIs) to the iOS 5.0 target already in place.

Changes have been tested and we are currently using the tvOS binaries with no issues so far.
