### PR TITLE
Don't catch a generic Exception following a multi-catch statement

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -1279,12 +1279,13 @@ public class StatementGenerator extends TreeVisitor {
     for (CatchClause cc : node.getCatchClauses()) {
       if (cc.getException().getType() instanceof UnionType) {
         printMultiCatch(cc);
+      } else {
+        buffer.append("@catch (");
+        cc.getException().accept(this);
+        buffer.append(") {\n");
+        printStatements(cc.getBody().getStatements());
+        buffer.append("}\n");
       }
-      buffer.append("@catch (");
-      cc.getException().accept(this);
-      buffer.append(") {\n");
-      printStatements(cc.getBody().getStatements());
-      buffer.append("}\n");
     }
 
     if (node.getFinally() != null) {

--- a/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/gen/StatementGeneratorTest.java
@@ -1399,6 +1399,7 @@ public class StatementGeneratorTest extends GenerationTest {
         "Test", "Test.m");
     assertTranslation(translation, "@catch (Test_FirstException *e) {\n    @throw e;\n  }");
     assertTranslation(translation, "@catch (Test_SecondException *e) {\n    @throw e;\n  }");
+    assertNotInTranslation(translation, "@catch (JavaLangException *e) {\n    @throw e;\n  }");
   }
 
   public void testDifferentTypesInConditionalExpression() throws IOException {


### PR DESCRIPTION
Currently a multi-catch statement like:

    catch (A | B e) {}

is translated to _three_ objc `@catch` clauses:

    @catch (A *e) {}
    @catch (B *e) {}
    @catch (JavaLangRuntimeException *e) {}

The last `@catch` clause seems to be the closest common ancestor of `A` and `B`, but from what I understand, this doesn't match the semantics of the Java multi-catch syntax. In fact, if the multi-catch is followed by a `catch (C e) {}`, where `C` also inherits `RuntimeException`, the translated `@catch (C *e)` clause is never reached because it is shadowed by the extraneous `@catch` clause.

This pull request changes the translation to omit the extra `@catch` clause after a multi-catch. Please review because I can't help but think that the extra `@catch` clause was previously being generated intentionally.