### PR TITLE
Implementation of getServerCertificates for HttpsURLConnection

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -549,22 +549,19 @@ public class IosHttpURLConnection extends HttpURLConnection {
       completionHandler(nil);
     }
   }]-*/
-  
 
   protected List<Certificate> certificates = new ArrayList<Certificate>();
-  private static CertificateFactory certificateFactory = null;
-  
-  static {
-    try {
-      certificateFactory = CertificateFactory.getInstance("X.509");
-    }catch (CertificateException ex)
-    {
-      // this will probably never happen
-    }
-  }
   
   private void addToCertificateList(final byte[] rawCert) throws CertificateException {
     ByteArrayInputStream certificateInputStream = new ByteArrayInputStream(rawCert);
+    
+    CertificateFactory certificateFactory = null;
+    try {
+      certificateFactory = CertificateFactory.getInstance("X.509");
+    }catch (CertificateException ex) {
+      // this will probably never happen
+    }
+    
     Certificate certificate = (Certificate) certificateFactory.generateCertificate(certificateInputStream);
     certificates.add(certificate);
   }

--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -17,6 +17,7 @@
 
 package com.google.j2objc.net;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +29,9 @@ import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -544,6 +548,42 @@ public class IosHttpURLConnection extends HttpURLConnection {
     } else {
       completionHandler(nil);
     }
+  }]-*/
+  
+
+  protected List<Certificate> certificates = new ArrayList<Certificate>();
+  private static CertificateFactory certificateFactory = null;
+  
+  static {
+    try {
+      certificateFactory = CertificateFactory.getInstance("X.509");
+    }catch (CertificateException ex)
+    {
+      // this will probably never happen
+    }
+  }
+  
+  private void addToCertificateList(final byte[] rawCert) throws CertificateException {
+    ByteArrayInputStream certificateInputStream = new ByteArrayInputStream(rawCert);
+    Certificate certificate = (Certificate) certificateFactory.generateCertificate(certificateInputStream);
+    certificates.add(certificate);
+  }
+  
+  /*-[- (void)URLSession:(NSURLSession *)session
+                didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+                completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                NSURLCredential *credential))completionHandler {
+    SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+    CFIndex count = SecTrustGetCertificateCount(serverTrust);
+    
+    for (CFIndex i=0; i<count; i++) {
+      SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, i);
+      NSData* remoteCertificateData = (__bridge NSData *) SecCertificateCopyData(certificate);
+      IOSByteArray* rawCert = [IOSByteArray arrayWithNSData:remoteCertificateData];
+      [self addToCertificateListWithByteArray:rawCert];
+    }
+    
+    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:serverTrust]);
   }]-*/
 
   private void addHeader(String k, String v) {

--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpsURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpsURLConnection.java
@@ -60,14 +60,21 @@ public class IosHttpsURLConnection extends HttpsURLConnection {
     return new Certificate[0];
   }
 
+  // Delegate methods.
   @Override
   public Certificate[] getServerCertificates() throws SSLPeerUnverifiedException {
-    // TODO(tball): implement
-    logger.severe("HttpsURLConnection.getServerCertificates() not implemented");
-    return new Certificate[0];
+    if (getURL().getHost().startsWith("http://")) {
+      throw new SSLPeerUnverifiedException("The http protocol does not support certificates");
+    }
+      
+    List<Certificate> certificates = delegate.certificates;
+    
+    if (certificates != null && !certificates.isEmpty()) {
+      return certificates.toArray(new Certificate[certificates.size()]);
+    }
+    
+    return null;
   }
-
-  // Delegate methods.
 
   @Override public void connect() throws IOException {
     connected = true;

--- a/jre_emul/Classes/com/google/j2objc/security/cert/IosCertificateFactory.java
+++ b/jre_emul/Classes/com/google/j2objc/security/cert/IosCertificateFactory.java
@@ -61,8 +61,7 @@ public class IosCertificateFactory extends CertificateFactorySpi {
   private native Certificate iosGenerateCertificate(byte[] bytes) throws CertificateException /*-[
     NSData *data = [[NSData alloc] initWithBytesNoCopy:bytes->buffer_ length:bytes->size_];
     SecCertificateRef newCertificate =
-        SecCertificateCreateWithData(NULL, (ARCBRIDGE CFDataRef) data);
-    [data release];
+        SecCertificateCreateWithData(NULL, (__bridge CFDataRef) data);
     if (!newCertificate) {
       @throw AUTORELEASE([[JavaSecurityCertCertificateException alloc]
                           initWithNSString:@"not a valid DER-encoded X.509 certificate"]);

--- a/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
+++ b/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
@@ -90,16 +90,6 @@ public class IosX509Certificate extends X509Certificate {
     }
   }
 
-// Moved to native finalize()
-/*
-- (void)dealloc {
-  CFRelease((SecCertificateRef) secCertificateRef_);
-#if ! __has_feature(objc_arc)
-  [super dealloc];
-#endif
-}
-*/
-
   @Override
   native protected void finalize() throws Throwable /*-[
     CFRelease((SecCertificateRef) secCertificateRef_);

--- a/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
+++ b/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
@@ -17,6 +17,8 @@
 
 package com.google.j2objc.security.cert;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -31,6 +33,14 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Set;
+
+// ASN.1 Decoder
+import org.apache.harmony.security.utils.AlgNameMapper;
+import org.apache.harmony.security.x509.Certificate;
+import org.apache.harmony.security.x509.Extension;
+import org.apache.harmony.security.x509.Extensions;
+import org.apache.harmony.security.x509.TBSCertificate;
+
 
 /*-[
 #include "NSDataInputStream.h"
@@ -52,19 +62,49 @@ import java.util.Set;
 public class IosX509Certificate extends X509Certificate {
 
   private long secCertificateRef;
+  
+  private Certificate certificate;
+  private TBSCertificate tbsCert;
+  private Extensions extensions;
 
   public IosX509Certificate(long secCertificateRef) {
     this.secCertificateRef = secCertificateRef;
   }
+  
+  /**
+   * This implementation is modelled after harmony's X509CertImpl
+   */
+  public void lazyDecoding() {
+    if (this.certificate == null)
+    {
+      try {
+        // decode the Certificate object
+        this.certificate = (Certificate) Certificate.ASN1.decode(new ByteArrayInputStream(getEncoded()));
+        // cache the values of TBSCertificate and Extensions
+        this.tbsCert = certificate.getTbsCertificate();
+        this.extensions = tbsCert.getExtensions();
+      } catch (CertificateEncodingException e) {
+        throw new RuntimeException(e);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
 
-/*-[
+// Moved to native finalize()
+/*
 - (void)dealloc {
   CFRelease((SecCertificateRef) secCertificateRef_);
 #if ! __has_feature(objc_arc)
   [super dealloc];
 #endif
 }
-]-*/
+*/
+
+  @Override
+  native protected void finalize() throws Throwable /*-[
+    CFRelease((SecCertificateRef) secCertificateRef_);
+  ]-*/;
 
   @Override
   public void checkValidity() throws CertificateExpiredException,
@@ -108,12 +148,12 @@ public class IosX509Certificate extends X509Certificate {
     // It's valid!
   ]-*/;
 
-  @Override
-  public native String toString() /*-[
-    return (ARCBRIDGE NSString *) SecCertificateCopySubjectSummary(
-        (SecCertificateRef) secCertificateRef_);
-  ]-*/;
+  
+  @Override public String toString() { lazyDecoding(); return certificate.toString(); }
 
+  /**
+   * This can be used for full certificate pinning
+   */
   @Override
   public native byte[] getEncoded() throws CertificateEncodingException /*-[
     CFDataRef dataRef = SecCertificateCopyData((SecCertificateRef) secCertificateRef_);
@@ -126,6 +166,7 @@ public class IosX509Certificate extends X509Certificate {
   // AssertionErrors are thrown for the two verify() methods, so that we aren't
   // accidentally "verifying" unchecked keys.
 
+  // TODO
   @Override
   public void verify(PublicKey key) throws CertificateException,
       NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
@@ -134,6 +175,7 @@ public class IosX509Certificate extends X509Certificate {
     throw new AssertionError("not implemented");
   }
 
+  // TODO
   @Override
   public void verify(PublicKey key, String sigProvider)
       throws CertificateException, NoSuchAlgorithmException,
@@ -142,107 +184,139 @@ public class IosX509Certificate extends X509Certificate {
     throw new AssertionError("not implemented");
   }
 
-  // The X509 certificate properties are not available from the iOS Security
-  // Framework API. To get this properties would require an ASN.1 decoder, so
-  // only implement these when they are required.
+  // The X509 certificate properties are indirectly available from the iOS Security
+  // Framework API. To get this properties would require an ASN.1 decoder
+  // We have these things since commit fa9c48a1 and 592382e0
+  // by using harmony's TBSCertificate, Certificate, etc.
 
+  // #getPublicKey#getEncoded can be used for public key pinning
   @Override
   public PublicKey getPublicKey() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getSubjectPublicKeyInfo().getPublicKey();
   }
 
   @Override
   public BigInteger getSerialNumber() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getSerialNumber();
   }
 
   @Override
   public Set<String> getCriticalExtensionOIDs() {
-    return null;
+    lazyDecoding();
+    return extensions.getCriticalExtensions();
   }
 
   @Override
   public byte[] getExtensionValue(String oid) {
-    return null;
+    lazyDecoding();
+    Extension ext = extensions.getExtensionByOID(oid);
+    return (ext == null) ? null : ext.getRawExtnValue();
   }
 
   @Override
   public Set<String> getNonCriticalExtensionOIDs() {
-    return null;
+    lazyDecoding();
+    return extensions.getNonCriticalExtensions();
   }
 
   @Override
   public boolean hasUnsupportedCriticalExtension() {
-    return false;
+    lazyDecoding();
+    return extensions.hasUnsupportedCritical();
   }
 
   @Override
   public int getVersion() {
-    return 0;
+    lazyDecoding();
+    return tbsCert.getVersion() + 1; // TODO determine why +1
   }
 
   @Override
   public Principal getIssuerDN() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getIssuer().getX500Principal();
   }
 
   @Override
   public Principal getSubjectDN() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getSubject().getX500Principal();
   }
 
   @Override
   public Date getNotBefore() {
-    return null;
+    lazyDecoding();
+    return new Date(tbsCert.getValidity().getNotBefore().getTime());
   }
 
   @Override
   public Date getNotAfter() {
-    return null;
+    lazyDecoding();
+    return new Date(tbsCert.getValidity().getNotAfter().getTime());
   }
 
   @Override
   public byte[] getTBSCertificate() throws CertificateEncodingException {
-    return null;
+    lazyDecoding();
+    return tbsCert.getEncoded();
   }
 
   @Override
   public byte[] getSignature() {
-    return null;
+    lazyDecoding();
+    return certificate.getSignatureValue();
   }
 
   @Override
   public String getSigAlgName() {
-    return null;
+    lazyDecoding();
+    // if info was not retrieved (and cached), do it:
+    final String sigAlgOID = tbsCert.getSignature().getAlgorithm();
+    // retrieve the name of the signing algorithm
+    String sigAlgName = AlgNameMapper.map2AlgName(sigAlgOID);
+    if (sigAlgName == null) {
+        // if could not be found, use OID as a name
+        sigAlgName = sigAlgOID;
+    }
+    return sigAlgName;
   }
 
   @Override
   public String getSigAlgOID() {
-    return null;
+    // according to my reference impl its the same
+    // see org.apache.harmony.security.provider.cert.X509CertImpl
+    return getSigAlgName();
   }
 
   @Override
   public byte[] getSigAlgParams() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getSignature().getParameters();
   }
 
   @Override
   public boolean[] getIssuerUniqueID() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getIssuerUniqueID();
   }
 
   @Override
   public boolean[] getSubjectUniqueID() {
-    return null;
+    lazyDecoding();
+    return tbsCert.getSubjectUniqueID();
   }
 
   @Override
   public boolean[] getKeyUsage() {
-    return null;
+    lazyDecoding();
+    return extensions.valueOfKeyUsage();
   }
 
   @Override
   public int getBasicConstraints() {
-    return 0;
+    lazyDecoding();
+    return extensions.valueOfBasicConstraints();
   }
 }

--- a/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
+++ b/jre_emul/Classes/com/google/j2objc/security/cert/IosX509Certificate.java
@@ -75,8 +75,7 @@ public class IosX509Certificate extends X509Certificate {
    * This implementation is modelled after harmony's X509CertImpl
    */
   public void lazyDecoding() {
-    if (this.certificate == null)
-    {
+    if (this.certificate == null) {
       try {
         // decode the Certificate object
         this.certificate = (Certificate) Certificate.ASN1.decode(new ByteArrayInputStream(getEncoded()));
@@ -149,7 +148,11 @@ public class IosX509Certificate extends X509Certificate {
   ]-*/;
 
   
-  @Override public String toString() { lazyDecoding(); return certificate.toString(); }
+  @Override
+  public String toString() {
+    lazyDecoding();
+    return certificate.toString();
+  }
 
   /**
    * This can be used for full certificate pinning
@@ -185,9 +188,8 @@ public class IosX509Certificate extends X509Certificate {
   }
 
   // The X509 certificate properties are indirectly available from the iOS Security
-  // Framework API. To get this properties would require an ASN.1 decoder
-  // We have these things since commit fa9c48a1 and 592382e0
-  // by using harmony's TBSCertificate, Certificate, etc.
+  // Framework API. The ASN.1 decoder from Apache Harmony is used to expand the raw
+  // format returned by the Security Framework.
 
   // #getPublicKey#getEncoded can be used for public key pinning
   @Override
@@ -230,7 +232,7 @@ public class IosX509Certificate extends X509Certificate {
   @Override
   public int getVersion() {
     lazyDecoding();
-    return tbsCert.getVersion() + 1; // TODO determine why +1
+    return tbsCert.getVersion();
   }
 
   @Override
@@ -285,7 +287,6 @@ public class IosX509Certificate extends X509Certificate {
 
   @Override
   public String getSigAlgOID() {
-    // according to my reference impl its the same
     // see org.apache.harmony.security.provider.cert.X509CertImpl
     return getSigAlgName();
   }

--- a/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/net/URLConnectionTest.java
+++ b/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/net/URLConnectionTest.java
@@ -2125,33 +2125,6 @@ public final class URLConnectionTest extends TestCase {
 //    }
 
     /**
-     * Test that we can inspect the SSL session after connect().
-     * http://code.google.com/p/android/issues/detail?id=24431
-     */
-    public void testInspectSslAfterConnect() throws Exception {
-        HttpsURLConnection connection = (HttpsURLConnection) new URL("https://www.google.com").openConnection();
-        
-        connection.connect();
-        
-        InputStream is = connection.getInputStream();
-        
-        final Certificate[] certs = connection.getServerCertificates();
-        
-        assertNotNull(certs);
-
-        for (Certificate cert : certs)
-        {
-            System.out.println(cert.toString());
-            assertNotNull(cert.getPublicKey().getEncoded());
-        }
-
-//        assertNotNull(connection.getHostnameVerifier());
-//        assertNull(connection.getLocalCertificates());
-//        assertNotNull(connection.getCipherSuite());
-//        assertNotNull(connection.getPeerPrincipal());
-    }
-
-    /**
      * Returns a gzipped copy of {@code bytes}.
      */
     public byte[] gzip(byte[] bytes) throws IOException {

--- a/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/net/URLConnectionTest.java
+++ b/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/net/URLConnectionTest.java
@@ -49,6 +49,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,8 +64,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import javax.net.ssl.HttpsURLConnection;
+
 
 import junit.framework.TestCase;
+
 
 public final class URLConnectionTest extends TestCase {
 
@@ -2118,6 +2123,33 @@ public final class URLConnectionTest extends TestCase {
 //        } catch (UnknownHostException expected) {
 //        }
 //    }
+
+    /**
+     * Test that we can inspect the SSL session after connect().
+     * http://code.google.com/p/android/issues/detail?id=24431
+     */
+    public void testInspectSslAfterConnect() throws Exception {
+        HttpsURLConnection connection = (HttpsURLConnection) new URL("https://www.google.com").openConnection();
+        
+        connection.connect();
+        
+        InputStream is = connection.getInputStream();
+        
+        final Certificate[] certs = connection.getServerCertificates();
+        
+        assertNotNull(certs);
+
+        for (Certificate cert : certs)
+        {
+            System.out.println(cert.toString());
+            assertNotNull(cert.getPublicKey().getEncoded());
+        }
+
+//        assertNotNull(connection.getHostnameVerifier());
+//        assertNull(connection.getLocalCertificates());
+//        assertNotNull(connection.getCipherSuite());
+//        assertNotNull(connection.getPeerPrincipal());
+    }
 
     /**
      * Returns a gzipped copy of {@code bytes}.

--- a/jre_emul/misc-tests/InspectSSLAfterConnect.java
+++ b/jre_emul/misc-tests/InspectSSLAfterConnect.java
@@ -1,0 +1,56 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.cert.Certificate;
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Test that we can inspect the SSL session after connect()
+ *
+ * Move to here from the test suite, due to security concerns
+ */
+final public class InspectSSLAfterConnect {
+  private static HttpsURLConnection connection;
+  private static InputStream inputStream;
+  private static Certificate[] certs;
+
+  public static void main(String[] args) {
+    try {
+        connect();
+		printSSLCertificates();
+	    printPublicKeysHexEncoded();
+	} catch (Exception e) {
+		e.printStackTrace();
+	}
+  }
+  
+  public static void connect() throws MalformedURLException, IOException {
+    connection = (HttpsURLConnection) new URL("https://www.google.com").openConnection();
+    connection.connect();
+    inputStream = connection.getInputStream();
+  }
+  
+  public static void printSSLCertificates() throws Exception {
+    certs = connection.getServerCertificates();
+    for (Certificate cert : certs) {
+      System.out.println(cert.toString());
+    }
+  }
+  
+  // tip: One way to do cross-platform public key/certificate pinning
+  // is to add your public key pin set via your build.gradle BuildConfig params
+  // e.g. BuildConfigField "String[]", "HTTPS_PINSET", "new String[] { ... }"
+  // then compare it in runtime with the ones fetched from the server
+  // as a bonus you could also compare the salted MessageDigest (e.g. SHA-256) results
+  public static void printPublicKeysHexEncoded() {
+    StringBuilder sb = new StringBuilder();
+    for (Certificate cert : certs) {
+      for (byte b : cert.getPublicKey().getEncoded()) {
+        sb.append(String.format("%02X ", b));
+      }
+      sb.append("\n");
+    }
+    System.out.println(sb.toString());
+  }
+}


### PR DESCRIPTION
I implemented NSURLSessionDelegate's NSURLAuthenticationChallenge delegate to get the
raw DER data.

Then java.security.cert.CertificateFactory generates the
required (X509)Certificate[].

Apache harmony's Certificate types and ASN.1 DER parser are used in the
underlying implementation of IosX509Certificate to get the fields
contained in the certificate.

The #verify methods aren't implemented yet. Baby steps.

My aim was to do full certificate and public key pinning, with the same codebase.