### PR TITLE
HttpURLConnection.getHeaderField() should be case-insensitive

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -598,7 +598,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 
   private void setHeader(String k, String v) {
     for (HeaderEntry entry : headers) {
-      if (entry.key == k) {
+      if (entry.key == k || (entry.key != null && k != null && k.equalsIgnoreCase(entry.key))) {
         headers.remove(entry);
         break;
       }

--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -180,7 +180,7 @@ public class IosHttpURLConnection extends HttpURLConnection {
         }
         continue;
       }
-      if (key.equals(entry.getKey())) {
+      if (entry.getKey() != null && key.equalsIgnoreCase(entry.getKey())) {
         return entry.getValue();
       }
     }


### PR DESCRIPTION
This fixes a bug where `HttpUrlConnection.getHeaderField(String)` was comparing keys in a case-sensitive way. I didn't see any existing tests for this class so I got lazy about creating one for this small fix.