### PR TITLE
Add package prefixed filename

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/Options.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/Options.java
@@ -547,6 +547,7 @@ public class Options {
       nullability = true;
     }
 
+    // Package prefixed filenames is only supported in combination with
     if (packagePrefixedFilenames && (outputStyle != OutputStyleOption.NONE)) {
       ErrorUtil.error(
           "--package-prefixed-filenames is only supported in combination with --no-package-directories");
@@ -562,7 +563,6 @@ public class Options {
       batchTranslateMaximum = SourceVersion.java7Minimum(sourceVersion) ? 300 : 0;
     }
 
-    // Package prefixed filenames is only supported in combination with
     int nFiles = args.length - nArg;
     String[] files = new String[nFiles];
     for (int i = 0; i < nFiles; i++) {

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/GenerationUnit.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/GenerationUnit.java
@@ -1,15 +1,13 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.google.devtools.j2objc.gen;
 
@@ -24,6 +22,7 @@ import com.google.devtools.j2objc.ast.NativeDeclaration;
 import com.google.devtools.j2objc.ast.PackageDeclaration;
 import com.google.devtools.j2objc.ast.TreeUtil;
 import com.google.devtools.j2objc.file.InputFile;
+import com.google.devtools.j2objc.util.NameTable;
 
 import java.io.File;
 import java.util.Collection;
@@ -34,8 +33,8 @@ import javax.annotation.Nullable;
 /**
  * A single unit of generated code, to be turned into a single pair of .h and .m files.
  * <p/>
- * Some attributes, like the name and output path, might not be known before parsing.
- * These are set by a {@link com.google.devtools.j2objc.FileProcessor}.
+ * Some attributes, like the name and output path, might not be known before parsing. These are set
+ * by a {@link com.google.devtools.j2objc.FileProcessor}.
  *
  * @author Mike Thvedt
  */
@@ -206,9 +205,9 @@ public class GenerationUnit {
   }
 
   /**
-   * Gets the output path if there isn't one already.
-   * For example, foo/bar/Mumble.java translates to $(OUTPUT_DIR)/foo/bar/Mumble.
-   * If --no-package-directories is specified, though, the output file is $(OUTPUT_DIR)/Mumble.
+   * Gets the output path if there isn't one already. For example, foo/bar/Mumble.java translates to
+   * $(OUTPUT_DIR)/foo/bar/Mumble. If --no-package-directories is specified, though, the output file
+   * is $(OUTPUT_DIR)/Mumble.
    */
   private static String getDefaultOutputPath(CompilationUnit unit) {
     String path = unit.getMainTypeName();
@@ -216,6 +215,9 @@ public class GenerationUnit {
     if (Options.usePackageDirectories() && !pkg.isDefaultPackage()) {
       path = pkg.getName().getFullyQualifiedName().replace('.', File.separatorChar)
           + File.separatorChar + path;
+    } else if (Options.generatePackagePrefixedFilenames()) {
+      // Prepend the package in camelcase to the class
+      path = NameTable.camelCaseQualifiedName(pkg.getName().getFullyQualifiedName()) + path;
     }
     return path;
   }

--- a/translator/src/main/java/com/google/devtools/j2objc/util/HeaderMap.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/HeaderMap.java
@@ -102,7 +102,13 @@ public class HeaderMap {
     if (Options.usePackageDirectories() || isPlatformClass(qualifiedName)) {
       return qualifiedName.replace('.', '/') + ".h";
     } else {
-      return qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1) + ".h";
+        // Do we need to prefix the filenames with the package name? E.g. the class foo.bar.Hello would create
+        // a filename FooBarHello.h
+        if (Options.generatePackagePrefixedFilenames()) {
+          return NameTable.camelCaseQualifiedName(qualifiedName)+".h";
+        } else {
+          return qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1) + ".h";
+        }
     }
   }
 

--- a/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
+++ b/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
@@ -57,6 +57,8 @@ Other options:\n\
   --no-package-directories     Generate output files to specified directory, without\
   \n                               creating package sub-directories.\n\
   --nullability                Converts Nullable and Nonnull annotations to Objective-C.\n\
+  --package-prefixed-filenames Generate output filenames that have the containing class' package \
+  \n                               name prefixed. Only works in combination with --no-package-directories.\n\
   --prefix <package=prefix>    Substitute a specified prefix for a package name.\n\
   --prefixes <file>            Specify a properties file with prefix definitions.\n\
   --preserve-full-paths        Generates output files with the same relative paths as \


### PR DESCRIPTION
Hi,

this adds an option --package-prefixed-filenames which will mangle the output filename to FooBarTest for a java class foo.bar.Test . It only works in combination with --no-package-directories.

Although i'm unable to write proper unit-tests things seem to be alright, j2objc itself compiles and the generated output compiles as well (in my case(s)).

Regards,
## 

Michel
