### PR TITLE
Don't redeclare generic private method in subclass

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/AbstractMethodRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/AbstractMethodRewriter.java
@@ -129,7 +129,7 @@ public class AbstractMethodRewriter extends UnitTreeVisitor {
     for (DeclaredType inheritedType : typeUtil.getObjcOrderedInheritedTypes(type.asType())) {
       TypeElement inheritedElem = (TypeElement) inheritedType.asElement();
       for (ExecutableElement methodElem : ElementUtil.getMethods(inheritedElem)) {
-        if (methodElem.getModifiers().contains(Modifier.PRIVATE)) {
+        if (ElementUtil.isPrivate(methodElem)) {
           continue;
         }
         TypeMirror declaredReturnType = typeUtil.erasure(methodElem.getReturnType());

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/AbstractMethodRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/AbstractMethodRewriter.java
@@ -129,6 +129,9 @@ public class AbstractMethodRewriter extends UnitTreeVisitor {
     for (DeclaredType inheritedType : typeUtil.getObjcOrderedInheritedTypes(type.asType())) {
       TypeElement inheritedElem = (TypeElement) inheritedType.asElement();
       for (ExecutableElement methodElem : ElementUtil.getMethods(inheritedElem)) {
+        if (methodElem.getModifiers().contains(Modifier.PRIVATE)) {
+          continue;
+        }
         TypeMirror declaredReturnType = typeUtil.erasure(methodElem.getReturnType());
         if (!TypeUtil.isReferenceType(declaredReturnType)) {
           continue;  // Short circuit

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/AbstractMethodRewriterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/AbstractMethodRewriterTest.java
@@ -89,4 +89,19 @@ public class AbstractMethodRewriterTest extends GenerationTest {
     assertTranslation(cHeader, "- (NSString *)foo;");
     assertNotInTranslation(cSource, "foo");
   }
+
+  public void testGenericPrivateMethodNotAdded() throws IOException {
+    String superSource = "abstract class Super<T> { "
+        + "  private T returnT() { return null; } "
+        + "}";
+    String subSource = "class Sub extends Super<Void> {}";
+    addSourceFile(superSource, "Super.java");
+    addSourceFile(subSource, "Sub.java");
+    String superTranslation = translateSourceFile("Super", "Super.m");
+    String subTranslation = translateSourceFile("Sub", "Sub.m");
+    // Super translation should contain the generic private method declaration.
+    assertTranslation(superTranslation, "- (id)returnT;");
+    // But Sub translation should not even though the return type is now resolved.
+    assertNotInTranslation(subTranslation, "returnT");
+  }
 }


### PR DESCRIPTION
If a superclass contains a method that returns a parameterized type, a subclass that narrows that type shouldn't include a declaration of that method in the .m file if it is a private method since the subclass is restricted from calling that method. In practice, this was causing compilation errors if the method argument list contained types that are not already imported in the subclass.

This patch fixes the issue and includes a test case.