### PR TITLE
Fix for IosHttpURLConnection not validating SSL certificates

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -785,10 +785,11 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
         IOSByteArray* rawCert = [IOSByteArray arrayWithNSData:remoteCertificateData];
         [securityDataHandler_ handleSecCertificateDataWithByteArray:rawCert];
       }
-
-      completionHandler(NSURLSessionAuthChallengeUseCredential,
-          [NSURLCredential credentialForTrust:serverTrust]);
     }
+
+    // Continue with default handling
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+
   }
   ]-*/
 


### PR DESCRIPTION
IosHttpURLConnection currently does not validate SSL certificates.
This change updates the URLSession didReceiveChallenge delegate method
to complete with NSURLSessionAuthChallengePerformDefaultHandling to
allow iOS to handle TLS challenge.