### PR TITLE
IosHttpURLConnection - stop NSURLSession caching to disk when useCaches is false     

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
+++ b/jre_emul/Classes/com/google/j2objc/net/IosHttpURLConnection.java
@@ -654,6 +654,19 @@ public class IosHttpURLConnection extends HttpURLConnection {
   ]-*/
 
   /*
+   * NSURLSessionDataDelegate method: should we store the response in the cache.
+   */
+  /*-[
+  - (void)URLSession:(NSURLSession *)session
+            dataTask:(NSURLSessionDataTask *)dataTask
+   willCacheResponse:(NSCachedURLResponse *)proposedResponse
+   completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler {
+    completionHandler( self->useCaches_ ? proposedResponse : nil );
+  }
+  ]-*/
+
+
+  /*
    * NSURLSessionDelegate method: task completed.
    */
   /*-[


### PR DESCRIPTION
NSURLSession has a response cache that is on by default. This change disables the
cache when HttpURLConnection.useCaches is false.

This pull came about from a need to stop http responses being written to device storage
for security reasons.