### PR TITLE
Fixed several issues of SystemClock.

### DIFF
--- a/jre_emul/android/frameworks/base/core/java/android/os/SystemClock.java
+++ b/jre_emul/android/frameworks/base/core/java/android/os/SystemClock.java
@@ -139,7 +139,7 @@ public final class SystemClock {
     }
 
     /*-[
-    static long long boottime_us() {
+    static long long boottime_usec() {
       // MIB = Management Information Base (man sysctl).
       #define MIB_SIZE 2
       int mib[MIB_SIZE];
@@ -156,17 +156,17 @@ public final class SystemClock {
       return ((long long) boottime.tv_sec) * 1.e6 + boottime.tv_usec;
     }
 
-    static long long uptime_us() {
+    static long long uptime_usec() {
       // source: http://stackoverflow.com/a/40497811
       long long before_now;
       long long after_now;
       struct timeval now;
 
-      after_now = boottime_us();
+      after_now = boottime_usec();
       do {
         before_now = after_now;
         gettimeofday(&now, NULL);
-        after_now = boottime_us();
+        after_now = boottime_usec();
       } while (after_now != before_now);
       return ((long long) now.tv_sec) * 1.e6 + now.tv_usec - before_now;
     }
@@ -178,7 +178,7 @@ public final class SystemClock {
      * @return elapsed milliseconds since boot.
      */
     public native static long elapsedRealtime() /*-[
-      return (long long)(uptime_us() / 1000.0);
+      return (long long)(uptime_usec() / 1000.0);
     ]-*/;
 
     /**
@@ -187,7 +187,7 @@ public final class SystemClock {
      * @return elapsed nanoseconds since boot.
      */
     public static native long elapsedRealtimeNanos() /*-[
-      return uptime_us() * 1000;
+      return uptime_usec() * 1000;
     ]-*/;
 
     /**


### PR DESCRIPTION
As an Android developer I was very happy to use `SystemClock` in the shared code for a media playing app which heavily relies on timers. Unfortunately I ran into the following issues:

* The iOS implementation of `elapsedRealtime()` is not monotonic, as the used `systemUptime` does not take sleep time into account.
The issue was hard to find, since it works in many cases and I was blind, knowing the contract of the Android's API ;)
* `elapsedRealtimeNanos()` returns the same value during the lifetime of a process, since it only returns the actual boot time of the system. But as the SO post below describes, even this fixed time can change, if the user/system changes the OS time.
The implementation of `elapsedRealtimeNanos()` actually has another issue: the returned value contains a timestamp in microseconds.

In my change I took the code of `elapsedRealtimeNanos()` to get the boot time in microseconds and used it to calculate the actual uptime based on this SO post: http://stackoverflow.com/q/12488481/1394330
I also took the warning of a race condition into account. `elapsedRealtimeNanos()` still uses the microseconds multiplied by 1000 to calculate the nanoseconds. This may be improved by using other APIs (?), but for now I'm ok with this ;)