### PR TITLE
Fix retain cycle by making Reader have @Weak reference to lock

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/java/io/Reader.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/java/io/Reader.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import com.google.j2objc.annotations.Weak;
 
 /**
  * Abstract class for reading character streams.  The only methods that a
@@ -57,7 +58,7 @@ public abstract class Reader implements Readable, Closeable {
      * the object in this field rather than <tt>this</tt> or a synchronized
      * method.
      */
-    protected Object lock;
+    @Weak protected Object lock;
 
     /**
      * Creates a new character-stream reader whose critical sections will


### PR DESCRIPTION
I believe there's a retain cycle leak in `Reader.lock`. I'm pretty sure this is the case when `this` is used as the lock, since a strong reference to itself is always a retain cycle unless broken elsewhere. In the case of `StreamDecoder` (a subclass of `Reader`), when used by `InputStreamReader` the ISR instance is used as the StreamDecoder's lock, while the ISR retains a strong reference to the StreamDecoder resulting in a retain cycle.

However, I'm not 100% sure if `@Weak` is safe to use here as I haven't yet audited every use of the lock constructor parameter and field. I could use some outside expertise in this case, since I'm not sure I have the time to check every caller.