### PR TITLE
RSA improvements

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKey.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKey.java
@@ -99,11 +99,11 @@ public abstract class IosRSAKey implements RSAKey, Key {
     }
 
     public IosRSAPublicKey(byte[] encoded) {
-        try {
-    	    iosSecKey = createPublicSecKeyRef (encoded);
-        } catch (Exception exp) {
-            throw new ProviderException(exp); // Should never happen.
-        }
+      try {
+        iosSecKey = createPublicSecKeyRef (encoded);
+       } catch (Exception exp) {
+         throw new ProviderException(exp); // Should never happen.
+       }
     }
 
     @Override
@@ -180,7 +180,7 @@ public abstract class IosRSAKey implements RSAKey, Key {
       return query;
     }
     ]-*/
-
+ 
     private native long createPublicSecKeyRef(byte[] bytes) /*-[
       NSData *publicKey = [[NSData alloc] initWithBytes:(const void *)(bytes->buffer_)
                                                  length:bytes->size_];

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
@@ -53,16 +53,17 @@ public class IosRSAKeyFactory extends KeyFactorySpi {
       throws InvalidKeySpecException {
 	  //The KeySpec for Private Key is PKCS8
 	if (keySpec instanceof PKCS8EncodedKeySpec ) {
-	    return new IosRSAKey.IosRSAPrivateKey(((PKCS8EncodedKeySpec) keySpec).getEncoded());  
+	  return new IosRSAKey.IosRSAPrivateKey(((PKCS8EncodedKeySpec) keySpec).getEncoded());  
 	}
     if (keySpec instanceof X509EncodedKeySpec) {
-        X509EncodedKeySpec x509Spec = (X509EncodedKeySpec) keySpec;
-        return new IosRSAKey.IosRSAPrivateKey(x509Spec.getEncoded());
+      X509EncodedKeySpec x509Spec = (X509EncodedKeySpec) keySpec;
+      return new IosRSAKey.IosRSAPrivateKey(x509Spec.getEncoded());
     } else if (keySpec instanceof RSAPrivateKeySpec) {
-        return new IosRSAKey.IosRSAPrivateKey((RSAPrivateKeySpec) keySpec);
+      return new IosRSAKey.IosRSAPrivateKey((RSAPrivateKeySpec) keySpec);
     }
     throw new InvalidKeySpecException(
-        "Must use PKCS8EncodedKeySpec, X509EncodedKeySpec or RSAPrivateKeySpec; was " + keySpec.getClass().getName());
+        "Must use PKCS8EncodedKeySpec, X509EncodedKeySpec or RSAPrivateKeySpec; was "
+            + keySpec.getClass().getName());
   }
 
   @Override

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
@@ -52,17 +52,17 @@ public class IosRSAKeyFactory extends KeyFactorySpi {
   protected PrivateKey engineGeneratePrivate(KeySpec keySpec)
       throws InvalidKeySpecException {
 	  //The KeySpec for Private Key is PKCS8
-	 if (keySpec instanceof PKCS8EncodedKeySpec ) {
-	     return new IosRSAKey.IosRSAPrivateKey(((PKCS8EncodedKeySpec) keySpec).getEncoded());  
-	 }
-    if (keySpec instanceof X509EncodedKeySpec || keySpec instanceof PKCS8EncodedKeySpec ) {
-      X509EncodedKeySpec x509Spec = (X509EncodedKeySpec) keySpec;
-      return new IosRSAKey.IosRSAPrivateKey(x509Spec.getEncoded());
+	if (keySpec instanceof PKCS8EncodedKeySpec ) {
+	    return new IosRSAKey.IosRSAPrivateKey(((PKCS8EncodedKeySpec) keySpec).getEncoded());  
+	}
+    if (keySpec instanceof X509EncodedKeySpec) {
+        X509EncodedKeySpec x509Spec = (X509EncodedKeySpec) keySpec;
+        return new IosRSAKey.IosRSAPrivateKey(x509Spec.getEncoded());
     } else if (keySpec instanceof RSAPrivateKeySpec) {
-      return new IosRSAKey.IosRSAPrivateKey((RSAPrivateKeySpec) keySpec);
+        return new IosRSAKey.IosRSAPrivateKey((RSAPrivateKeySpec) keySpec);
     }
     throw new InvalidKeySpecException(
-        "Must use PKCS8EncodedKeySpec; was " + keySpec.getClass().getName());
+        "Must use PKCS8EncodedKeySpec, X509EncodedKeySpec or RSAPrivateKeySpec; was " + keySpec.getClass().getName());
   }
 
   @Override
@@ -221,7 +221,4 @@ public class IosRSAKeyFactory extends KeyFactorySpi {
           "Key must be an RSA public or private key; was " + key.getClass().getName());
     }
   }
-  
-  
-
 }

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyFactory.java
@@ -51,14 +51,18 @@ public class IosRSAKeyFactory extends KeyFactorySpi {
   @Override
   protected PrivateKey engineGeneratePrivate(KeySpec keySpec)
       throws InvalidKeySpecException {
-    if (keySpec instanceof X509EncodedKeySpec) {
+	  //The KeySpec for Private Key is PKCS8
+	 if (keySpec instanceof PKCS8EncodedKeySpec ) {
+	     return new IosRSAKey.IosRSAPrivateKey(((PKCS8EncodedKeySpec) keySpec).getEncoded());  
+	 }
+    if (keySpec instanceof X509EncodedKeySpec || keySpec instanceof PKCS8EncodedKeySpec ) {
       X509EncodedKeySpec x509Spec = (X509EncodedKeySpec) keySpec;
       return new IosRSAKey.IosRSAPrivateKey(x509Spec.getEncoded());
     } else if (keySpec instanceof RSAPrivateKeySpec) {
       return new IosRSAKey.IosRSAPrivateKey((RSAPrivateKeySpec) keySpec);
     }
     throw new InvalidKeySpecException(
-        "Must use RSAPublicKeySpec; was " + keySpec.getClass().getName());
+        "Must use PKCS8EncodedKeySpec; was " + keySpec.getClass().getName());
   }
 
   @Override
@@ -217,5 +221,7 @@ public class IosRSAKeyFactory extends KeyFactorySpi {
           "Key must be an RSA public or private key; was " + key.getClass().getName());
     }
   }
+  
+  
 
 }

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyPairGenerator.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyPairGenerator.java
@@ -38,15 +38,13 @@ public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
 
   @Override
   public native KeyPair generateKeyPair() /*-[
-  
-
-	// Keys have to be deleted first, else the method will retrive previous keys.
+  	// Keys have to be deleted first, else the method will retrieve previous keys.
     // Delete any Public previous key definition.
     [self deleteKey:ComGoogleJ2objcSecurityIosRSAKey_PUBLIC_KEY_TAG
-    				   keyClass:kSecAttrKeyClassPublic];
+    	   keyClass:kSecAttrKeyClassPublic];
     				   
     [self deleteKey:ComGoogleJ2objcSecurityIosRSAKey_PRIVATE_KEY_TAG
-    				   keyClass:kSecAttrKeyClassPrivate];
+    	   keyClass:kSecAttrKeyClassPrivate];
   
     // Requested keypair attributes.
     NSMutableDictionary * keyPairAttr = [[NSMutableDictionary alloc] init];
@@ -92,7 +90,7 @@ public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
   ]-*/;
   
   /*-[
-  -(BOOL) deleteKey:(NSString *)tag   
+  -(void) deleteKey:(NSString *)tag   
   		   keyClass:(CFStringRef) keyClass {
   		   
     NSData *publicTag = [tag dataUsingEncoding:NSUTF8StringEncoding];
@@ -102,12 +100,17 @@ public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
     query[(id)kSecAttrKeyType] = (id)kSecAttrKeyTypeRSA;
     query[(id)kSecAttrKeyClass] = (id)keyClass;
     query[(id)kSecAttrApplicationTag] = tag;
-	OSStatus status2 = SecItemDelete((CFDictionaryRef) query);
-    if (status2 != errSecSuccess && status2 != errSecItemNotFound) {
-        NSLog (@"Problem removing previous public key from the keychain, OSStatus == %d", (int)status2);
-        return false;
+	OSStatus status = SecItemDelete((CFDictionaryRef) query);
+    if (status != errSecSuccess && status != errSecItemNotFound) {
+        NSString *msg = [NSString stringWithFormat:
+          @"Problem removing previous public key from the keychain, OSStatus == %d",
+          (int)status];
+          NSLog (@"%@", msg);
+          //TODO(tball):  @throw is causing this error error
+          // mplicit declaration of function 'create_JavaSecurityProviderException_initWithNSString_' is invalid in C99
+          // [-Werror,-Wimplicit-function-declaration]
+          // @throw create_JavaSecurityProviderException_initWithNSString_(msg);
     }
-    return true;
   }
   ]-*/
 

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyPairGenerator.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSAKeyPairGenerator.java
@@ -26,6 +26,7 @@ import java.security.spec.RSAKeyGenParameterSpec;
 
 /*-[
 #import "com/google/j2objc/security/IosRSAKey.h"
+#import "com/google/j2objc/security/IosRSAKeyFactory.h"
 ]-*/
 
 public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
@@ -37,6 +38,16 @@ public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
 
   @Override
   public native KeyPair generateKeyPair() /*-[
+  
+
+	// Keys have to be deleted first, else the method will retrive previous keys.
+    // Delete any Public previous key definition.
+    [self deleteKey:ComGoogleJ2objcSecurityIosRSAKey_PUBLIC_KEY_TAG
+    				   keyClass:kSecAttrKeyClassPublic];
+    				   
+    [self deleteKey:ComGoogleJ2objcSecurityIosRSAKey_PRIVATE_KEY_TAG
+    				   keyClass:kSecAttrKeyClassPrivate];
+  
     // Requested keypair attributes.
     NSMutableDictionary * keyPairAttr = [[NSMutableDictionary alloc] init];
     NSMutableDictionary *publicKeyAttr = [[NSMutableDictionary alloc] init];
@@ -74,10 +85,31 @@ public class IosRSAKeyPairGenerator extends KeyPairGeneratorSpi {
     JavaSecurityKeyPair *keyPair =
         AUTORELEASE([[JavaSecurityKeyPair alloc] initWithJavaSecurityPublicKey:publicKey
                                                     withJavaSecurityPrivateKey:privateKey]);
+
     [publicKey release];
     [privateKey release];
     return keyPair;
   ]-*/;
+  
+  /*-[
+  -(BOOL) deleteKey:(NSString *)tag   
+  		   keyClass:(CFStringRef) keyClass {
+  		   
+    NSData *publicTag = [tag dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSMutableDictionary *query = [NSMutableDictionary dictionary];
+    query[(id)kSecClass] = (id)kSecClassKey;
+    query[(id)kSecAttrKeyType] = (id)kSecAttrKeyTypeRSA;
+    query[(id)kSecAttrKeyClass] = (id)keyClass;
+    query[(id)kSecAttrApplicationTag] = tag;
+	OSStatus status2 = SecItemDelete((CFDictionaryRef) query);
+    if (status2 != errSecSuccess && status2 != errSecItemNotFound) {
+        NSLog (@"Problem removing previous public key from the keychain, OSStatus == %d", (int)status2);
+        return false;
+    }
+    return true;
+  }
+  ]-*/
 
   @Override
   public void initialize(int keySize, SecureRandom random) {

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSASignature.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSASignature.java
@@ -33,7 +33,6 @@ import java.security.interfaces.RSAPublicKey;
 #include "NSDataOutputStream.h"
 #include <CommonCrypto/CommonDigest.h>
 #include <Security/Security.h>
-#import <Foundation/Foundation.h>
 
 // Public iOS API (Security/SecKey.h). These functions are private in OS X due
 // to issues with ECC certificates, but are still useful for jre_emul unit tests.
@@ -170,8 +169,9 @@ public abstract class IosRSASignature extends SignatureSpi {
                          
     size_t signatureSize = SecKeyGetBlockSize(publicKey);
     if (signatureSize != (size_t)signature->size_) {
-    	NSLog (@"nativeEngineVerify: Wrong Signature Size %d %d", (int)signatureSize , (int) hashBytesSize );
-      return false;
+        NSLog (@"nativeEngineVerify: Wrong Signature Size %d %d", (int)signatureSize,
+        (int) hashBytesSize );
+        return false;
     }
     OSStatus status = SecKeyRawVerify(publicKey,
                                       secPadding,
@@ -181,8 +181,7 @@ public abstract class IosRSASignature extends SignatureSpi {
                                       signatureSize);
     if (status != errSecSuccess) {
       // Try verifying without padding.
-       NSLog (@"nativeEngineVerify: Signature with padding failed,  %d ", (int) status);
-
+      NSLog (@"nativeEngineVerify: Signature with padding failed,  %d ", (int) status);
       status = SecKeyRawVerify(publicKey,
                                kSecPaddingNone,
                                hashBytes,
@@ -190,10 +189,8 @@ public abstract class IosRSASignature extends SignatureSpi {
                                (uint8_t*)signature->buffer_,
                                signatureSize);
       if (status != errSecSuccess) {
-      // Try verifying without padding.
-       	NSLog (@"nativeEngineVerify: Signature failed,  %d ", (int) status);
-       }                         
-                               
+          NSLog (@"nativeEngineVerify: Signature failed,  %d ", (int) status);
+      }                         
     }
     return status == errSecSuccess;
   }
@@ -211,7 +208,7 @@ public abstract class IosRSASignature extends SignatureSpi {
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
                                                size:hashBytesSize 
-                                               padding:kSecPaddingPKCS1MD5];  
+                                            padding:kSecPaddingPKCS1MD5];  
       free(hashBytes);
       return result;
     ]-*/;
@@ -282,9 +279,9 @@ public abstract class IosRSASignature extends SignatureSpi {
                                           hashBytes:hashBytes
                                                size:hashBytesSize 
 #if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
-                                     padding:kSecPaddingPKCS1SHA256];  
+                                     padding:kSecPaddingPKCS1SHA256];
 #else
-                                     padding:kSecPaddingPKCS1SHA1];    
+                                     padding:kSecPaddingPKCS1SHA1];
 #endif
       free(hashBytes);
       return result;

--- a/jre_emul/Classes/com/google/j2objc/security/IosRSASignature.java
+++ b/jre_emul/Classes/com/google/j2objc/security/IosRSASignature.java
@@ -33,6 +33,7 @@ import java.security.interfaces.RSAPublicKey;
 #include "NSDataOutputStream.h"
 #include <CommonCrypto/CommonDigest.h>
 #include <Security/Security.h>
+#import <Foundation/Foundation.h>
 
 // Public iOS API (Security/SecKey.h). These functions are private in OS X due
 // to issues with ECC certificates, but are still useful for jre_emul unit tests.
@@ -142,11 +143,13 @@ public abstract class IosRSASignature extends SignatureSpi {
   /*-[
   - (IOSByteArray *)nativeEngineSign:(SecKeyRef)privateKey
                            hashBytes:(uint8_t *)hashBytes
-                                size:(size_t)hashBytesSize {
+                                size:(size_t)hashBytesSize
+                                padding: (SecPadding) padding {  
+                     
     size_t signedHashBytesSize = SecKeyGetBlockSize(privateKey);
     uint8_t *signedHashBytes = calloc(signedHashBytesSize, sizeof(uint8_t));
     SecKeyRawSign(privateKey,
-                  kSecPaddingNone,
+                  padding,										
                   hashBytes,
                   hashBytesSize,
                   signedHashBytes,
@@ -164,8 +167,10 @@ public abstract class IosRSASignature extends SignatureSpi {
                        hashBytes:(uint8_t *)hashBytes
                             size:(size_t)hashBytesSize
                          padding:(SecPadding)secPadding {
+                         
     size_t signatureSize = SecKeyGetBlockSize(publicKey);
     if (signatureSize != (size_t)signature->size_) {
+    	NSLog (@"nativeEngineVerify: Wrong Signature Size %d %d", (int)signatureSize , (int) hashBytesSize );
       return false;
     }
     OSStatus status = SecKeyRawVerify(publicKey,
@@ -176,12 +181,19 @@ public abstract class IosRSASignature extends SignatureSpi {
                                       signatureSize);
     if (status != errSecSuccess) {
       // Try verifying without padding.
+       NSLog (@"nativeEngineVerify: Signature with padding failed,  %d ", (int) status);
+
       status = SecKeyRawVerify(publicKey,
                                kSecPaddingNone,
                                hashBytes,
                                hashBytesSize,
                                (uint8_t*)signature->buffer_,
                                signatureSize);
+      if (status != errSecSuccess) {
+      // Try verifying without padding.
+       	NSLog (@"nativeEngineVerify: Signature failed,  %d ", (int) status);
+       }                         
+                               
     }
     return status == errSecSuccess;
   }
@@ -198,7 +210,8 @@ public abstract class IosRSASignature extends SignatureSpi {
       }
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
-                                               size:hashBytesSize];
+                                               size:hashBytesSize 
+                                               padding:kSecPaddingPKCS1MD5];  
       free(hashBytes);
       return result;
     ]-*/;
@@ -232,7 +245,8 @@ public abstract class IosRSASignature extends SignatureSpi {
       }
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
-                                               size:hashBytesSize];
+                                               size:hashBytesSize 
+                                            padding:kSecPaddingPKCS1SHA1];  
       free(hashBytes);
       return result;
     ]-*/;
@@ -266,7 +280,12 @@ public abstract class IosRSASignature extends SignatureSpi {
       }
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
-                                               size:hashBytesSize];
+                                               size:hashBytesSize 
+#if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
+                                     padding:kSecPaddingPKCS1SHA256];  
+#else
+                                     padding:kSecPaddingPKCS1SHA1];    
+#endif
       free(hashBytes);
       return result;
     ]-*/;
@@ -284,7 +303,7 @@ public abstract class IosRSASignature extends SignatureSpi {
                                    hashBytes:hashBytes
                                         size:hashBytesSize
 #if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
-                                     padding:kSecPaddingPKCS1SHA256];
+                                     padding:kSecPaddingPKCS1SHA256];  
 #else
                                      padding:kSecPaddingPKCS1SHA1];
 #endif
@@ -304,7 +323,12 @@ public abstract class IosRSASignature extends SignatureSpi {
       }
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
-                                               size:hashBytesSize];
+                                               size:hashBytesSize 
+#if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
+                                     padding:kSecPaddingPKCS1SHA384]; 
+#else
+                                     padding:kSecPaddingPKCS1SHA1];    
+#endif
       free(hashBytes);
       return result;
     ]-*/;
@@ -342,7 +366,13 @@ public abstract class IosRSASignature extends SignatureSpi {
       }
       IOSByteArray *result = [self nativeEngineSign:(SecKeyRef)nativeKey
                                           hashBytes:hashBytes
-                                               size:hashBytesSize];
+                                               size:hashBytesSize 
+#if (TARGET_OS_IPHONE || TARGET_OS_SIMULATOR)
+                                     padding:kSecPaddingPKCS1SHA512]; 
+#else
+                                     padding:kSecPaddingPKCS1SHA1];   
+#endif   
+                                               
       free(hashBytes);
       return result;
     ]-*/;


### PR DESCRIPTION
a) generating KeyPairs with different keys
Our requirements are to genereate KeyPairs for several users. I noticed
that the created KeyPairs created had all the same identical keys.
To solve this problem, in method generateKeyPair, I first deleted any
existing public/private keys. Then the keys were always created new.
see Class IosRSAKeyPairGenerator.java

b)RSA Sign padding
When RSASignature nativeEngineSign signs the message always with
"kSecPaddingNone" but the nativeEngineVerify method use PKCS1.
The output of the "sign" message is not comapatile with PKCS1. So I
changed RSASignature so that the method nativeEngineSign will also use
PKCS1 padding.
See class IosRSASignature.java

c) engineGeneratePrivate
The KeySpec for PrivateKey generation is PKCS8EncodedKeySpec. The method
engineGeneratePrivate was only considering X509EncodedKeySpec.
To solve this I implemented the check for PKCS8EncodedKeySpec.
See class IosRSAKeyFactory.java

d) endcoding the PrivateKey
The constructor IosRSAPrivateKey (byte [] encoded) was calling
"this(decode(encoded))" and this method tries to load a PrivateKey from
"SecCertificateCreateWithData".
But you cannot laod a Private Key from a DER certificate.
To solve the problem I implemented the method  "iosSecKey =
createPrivatSecKeyRef(encoded);"

e) Note about Public Key format
The iOS PublicKey format is not a PKCS1 standard, it is an ASN.1
sequence encoding of the modules and exponent. If you want to send the
ios PublicKey to for example a JAVA server you have to convert the
PubkeyKey encoding to PKCS1.
To make it a PKCS1 you just need to add the PKCS1 header.
For example the pkcs1 header for 2048 key is :
static byte[] pcks1Header = new byte[] { (byte) 0x30, (byte) 0x82,
(byte) 0x01, (byte) 0x22, (byte) 0x30,
            (byte) 0x0d, (byte) 0x06, (byte) 0x09, (byte) 0x2a, (byte)
0x86, (byte) 0x48, (byte) 0x86, (byte) 0xf7,
            (byte) 0x0d, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte)
0x05, (byte) 0x00, (byte) 0x03, (byte) 0x82,
            (byte) 0x01, (byte) 0x0f, (byte) 0x00 };