### PR TITLE
Add all output to a single Objective-C file set. Similar to combineJa…

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/Options.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/Options.java
@@ -82,6 +82,7 @@ public class Options {
   private boolean translateBootclasspath = false;
   private boolean translateClassfiles = false;
   private String annotationsJar = null;
+  private String globalCombinedOutput = null;
   private String bootclasspath = null;
 
   private Mappings mappings = new Mappings();
@@ -141,6 +142,14 @@ public class Options {
     for (Handler handler : rootLogger.getHandlers()) {
       handler.setLevel(Level.ALL);
     }
+  }
+
+  public String globalCombinedOutput() {
+    return globalCombinedOutput;
+  }
+
+  public void setGlobalCombinedOutput(String globalCombinedOutput) {
+    this.globalCombinedOutput = globalCombinedOutput;
   }
 
   /**
@@ -286,6 +295,8 @@ public class Options {
         headerMap.setOutputStyle(HeaderMap.OutputStyleOption.SOURCE);
       } else if (arg.equals("-XcombineJars")) {
         headerMap.setCombineJars();
+      } else if (arg.equals("-XglobalCombinedOutput")) {
+        setGlobalCombinedOutput(getArgValue(args, arg));
       } else if (arg.equals("-XincludeGeneratedSources")) {
         headerMap.setIncludeGeneratedSources();
       } else if (arg.equals("-use-arc")) {

--- a/translator/src/main/java/com/google/devtools/j2objc/pipeline/GenerationBatch.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/pipeline/GenerationBatch.java
@@ -47,8 +47,12 @@ public class GenerationBatch {
 
   private final List<ProcessingContext> inputs = Lists.newArrayList();
 
+  private GenerationUnit globalCombinedUnit = null;
+
   public GenerationBatch(Options options){
     this.options = options;
+    if (options.globalCombinedOutput() != null)
+      globalCombinedUnit = GenerationUnit.newCombinedJarUnit(options.globalCombinedOutput(), options);
   }
 
   public List<ProcessingContext> getInputs() {
@@ -129,7 +133,9 @@ public class GenerationBatch {
     }
 
     GenerationUnit combinedUnit = null;
-    if (options.getHeaderMap().combineSourceJars()) {
+    if (globalCombinedUnit != null) {
+      combinedUnit = globalCombinedUnit;
+    } else if (options.getHeaderMap().combineSourceJars()) {
       combinedUnit = GenerationUnit.newCombinedJarUnit(filename, options);
     }
     try {
@@ -178,6 +184,10 @@ public class GenerationBatch {
    */
   @VisibleForTesting
   public void addSource(InputFile file) {
-    inputs.add(ProcessingContext.fromFile(file, options));
+    if (globalCombinedUnit != null) {
+      inputs.add(new ProcessingContext(file, globalCombinedUnit));
+    } else {
+      inputs.add(ProcessingContext.fromFile(file, options));
+    }
   }
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/J2ObjCTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/J2ObjCTest.java
@@ -131,6 +131,13 @@ public class J2ObjCTest extends GenerationTest {
     makeAssertionsForJavaFiles(exampleH, exampleM, packageInfoH, packageInfoM);
   }
 
+  private void makeAssertionsForGlobalCombinedOutputJavaFiles() throws Exception {
+    String exampleH = getTranslatedFile("testGlobalCombinedOutputFile.h");
+    String exampleM = getTranslatedFile("testGlobalCombinedOutputFile.m");
+    assertTranslation(exampleM, "#include \"testGlobalCombinedOutputFile.h\"");
+    makeAssertionsForGlobalCombinedOutputJavaFiles(exampleH, exampleM);
+  }
+
   private void makeAssertionsForJavaFiles(
       String exampleH, String exampleM, String packageInfoH, String packageInfoM)
       throws Exception {
@@ -149,6 +156,19 @@ public class J2ObjCTest extends GenerationTest {
     assertTranslation(packageInfoM, "@implementation ComGoogleDevtoolsJ2objcUtilpackage_info");
     // All other assertions
     makeAssertions(exampleH, exampleM, packageInfoM);
+  }
+
+  private void makeAssertionsForGlobalCombinedOutputJavaFiles(
+          String exampleH, String exampleM)
+          throws Exception {
+    // Test the includes
+    assertTranslation(
+            exampleH, "#pragma push_macro(\"INCLUDE_ALL_TestGlobalCombinedOutputFile\")");
+    assertTranslation(
+            exampleM, "@interface ComGoogleDevtoolsJ2objcUtilpackage_info : NSObject");
+    assertTranslation(exampleM, "@implementation ComGoogleDevtoolsJ2objcUtilpackage_info");
+    // All other assertions
+    makeAssertions(exampleH, exampleM, exampleM);
   }
 
   public void testCompilingFromFiles() throws Exception {
@@ -174,6 +194,12 @@ public class J2ObjCTest extends GenerationTest {
     makeAssertionsForCombinedJar();
   }
 
+  public void testGlobalCombinedOutput() throws Exception {
+    options.setGlobalCombinedOutput("testGlobalCombinedOutputFile");
+    J2ObjC.run(Arrays.asList(exampleJavaPath, packageInfoPath), options);
+    makeAssertionsForGlobalCombinedOutputJavaFiles();
+  }
+  
   public void testSourceDirsOption() throws Exception {
     options.getHeaderMap().setOutputStyle(HeaderMap.OutputStyleOption.SOURCE);
     J2ObjC.run(Arrays.asList(exampleJavaPath, packageInfoPath), options);

--- a/translator/src/test/java/com/google/devtools/j2objc/J2ObjCTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/J2ObjCTest.java
@@ -158,14 +158,13 @@ public class J2ObjCTest extends GenerationTest {
     makeAssertions(exampleH, exampleM, packageInfoM);
   }
 
-  private void makeAssertionsForGlobalCombinedOutputJavaFiles(
-          String exampleH, String exampleM)
-          throws Exception {
+  private void makeAssertionsForGlobalCombinedOutputJavaFiles(String exampleH, String exampleM)
+      throws Exception {
     // Test the includes
     assertTranslation(
-            exampleH, "#pragma push_macro(\"INCLUDE_ALL_TestGlobalCombinedOutputFile\")");
+        exampleH, "#pragma push_macro(\"INCLUDE_ALL_TestGlobalCombinedOutputFile\")");
     assertTranslation(
-            exampleM, "@interface ComGoogleDevtoolsJ2objcUtilpackage_info : NSObject");
+        exampleM, "@interface ComGoogleDevtoolsJ2objcUtilpackage_info : NSObject");
     assertTranslation(exampleM, "@implementation ComGoogleDevtoolsJ2objcUtilpackage_info");
     // All other assertions
     makeAssertions(exampleH, exampleM, exampleM);
@@ -199,7 +198,7 @@ public class J2ObjCTest extends GenerationTest {
     J2ObjC.run(Arrays.asList(exampleJavaPath, packageInfoPath), options);
     makeAssertionsForGlobalCombinedOutputJavaFiles();
   }
-  
+
   public void testSourceDirsOption() throws Exception {
     options.getHeaderMap().setOutputStyle(HeaderMap.OutputStyleOption.SOURCE);
     J2ObjC.run(Arrays.asList(exampleJavaPath, packageInfoPath), options);


### PR DESCRIPTION
…rs, but can be for everything.

The general goal is to be able to send a whole bunch of java files into one Objc output file set. This is to solve a few problems.

1. Xcode doesn't consider paths distinct. Same file name in different paths is a problem (if added visually or with cocoapods)
2. Our usual combination of dependencies winds up with thousands of artifacts. Xcode seems to handle a single huge file much better than many small.
3. combineJar would work if we jar'd up the java and translated the jar, but you can't run java debug on it (the jar gets unzipped in a temp folder, so the #line directives point to non-existent files).

On the negative side, any change to the a single java file triggers a full rebuild of everything, but the usage flow we've had is to do dev in Java/Android, then translate and work in Swift. Usually not a big deal.

Our gradle plugin and framework had a moderately forked j2objc, but I've reduced that to this PR. If we can do this (or something equivalent), we'll be using a stock J2objc build and just publish a gradle plugin and libraries.

(I have another PR coming, but its just to output a warning suppression line)