### PR TITLE
ConcurrentSkipListMap: Use sentinel instead of self references

### DIFF
--- a/jre_emul/android/platform/libcore/luni/src/main/java/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/jre_emul/android/platform/libcore/luni/src/main/java/java/util/concurrent/ConcurrentSkipListMap.java
@@ -412,7 +412,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
          */
         Node(Node<K,V> next) {
             this.key = null;
-            this.value = this;
+            this.value = sentinel();
             this.next = next;
         }
 
@@ -474,7 +474,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
              * interference among helping threads.
              */
             if (f == next && this == b.next) {
-                if (f == null || f.value != f) // not already marked
+                if (f == null || f.value != sentinel()) // not already marked
                     casNext(f, new Node<K,V>(f));
                 else
                     b.casNext(this, f.next);
@@ -1085,7 +1085,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     n.helpDelete(b, f);
                     break;
                 }
-                if (b.value == null || v == n)      // b is deleted
+                if (b.value == null || v == sentinel())      // b is deleted
                     break;
                 if (f != null) {
                     b = n;
@@ -1144,7 +1144,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         n.helpDelete(b, f);
                         break;
                     }
-                    if (b.value == null || v == n)      // b is deleted
+                    if (b.value == null || v == sentinel())      // b is deleted
                         break;
                     b = n;
                     n = f;
@@ -2252,7 +2252,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
         Iter() {
             while ((next = findFirst()) != null) {
                 Object x = next.value;
-                if (x != null && x != next) {
+                if (x != null && x != sentinel()) {
                     @SuppressWarnings("unchecked") V vv = (V)x;
                     nextValue = vv;
                     break;
@@ -2271,7 +2271,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
             lastReturned = next;
             while ((next = next.next) != null) {
                 Object x = next.value;
-                if (x != null && x != next) {
+                if (x != null && x != sentinel()) {
                     @SuppressWarnings("unchecked") V vv = (V)x;
                     nextValue = vv;
                     break;
@@ -3070,7 +3070,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != next) {
+                    if (x != null && x != sentinel()) {
                         if (! inBounds(next.key, cmp))
                             next = null;
                         else {
@@ -3103,7 +3103,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != next) {
+                    if (x != null && x != sentinel()) {
                         if (tooHigh(next.key, cmp))
                             next = null;
                         else {
@@ -3122,7 +3122,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != next) {
+                    if (x != null && x != sentinel()) {
                         if (tooLow(next.key, cmp))
                             next = null;
                         else {
@@ -3577,6 +3577,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
     // Unsafe mechanics
     private static final sun.misc.Unsafe U = sun.misc.Unsafe.getUnsafe();
     private static final long HEAD;
+    private static final Node SENTINEL = new Node(null);
     static {
         try {
             HEAD = U.objectFieldOffset
@@ -3584,5 +3585,9 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
         } catch (ReflectiveOperationException e) {
             throw new Error(e);
         }
+    }
+
+    private static Node sentinel() {
+        return SENTINEL;
     }
 }


### PR DESCRIPTION
- The self references in the marker nodes are leaking
- as recommended, implement a sentinel instead

closes #946 

cc: @AlexandreHetu 