### PR TITLE
Revert "ConcurrentSkipListMap: Use sentinel instead of self references"

### DIFF
--- a/jre_emul/android/platform/libcore/luni/src/main/java/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/jre_emul/android/platform/libcore/luni/src/main/java/java/util/concurrent/ConcurrentSkipListMap.java
@@ -412,7 +412,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
          */
         Node(Node<K,V> next) {
             this.key = null;
-            this.value = sentinel();
+            this.value = this;
             this.next = next;
         }
 
@@ -474,7 +474,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
              * interference among helping threads.
              */
             if (f == next && this == b.next) {
-                if (f == null || f.value != sentinel()) // not already marked
+                if (f == null || f.value != f) // not already marked
                     casNext(f, new Node<K,V>(f));
                 else
                     b.casNext(this, f.next);
@@ -1085,7 +1085,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     n.helpDelete(b, f);
                     break;
                 }
-                if (b.value == null || v == sentinel())      // b is deleted
+                if (b.value == null || v == n)      // b is deleted
                     break;
                 if (f != null) {
                     b = n;
@@ -1144,7 +1144,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         n.helpDelete(b, f);
                         break;
                     }
-                    if (b.value == null || v == sentinel())      // b is deleted
+                    if (b.value == null || v == n)      // b is deleted
                         break;
                     b = n;
                     n = f;
@@ -2252,7 +2252,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
         Iter() {
             while ((next = findFirst()) != null) {
                 Object x = next.value;
-                if (x != null && x != sentinel()) {
+                if (x != null && x != next) {
                     @SuppressWarnings("unchecked") V vv = (V)x;
                     nextValue = vv;
                     break;
@@ -2271,7 +2271,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
             lastReturned = next;
             while ((next = next.next) != null) {
                 Object x = next.value;
-                if (x != null && x != sentinel()) {
+                if (x != null && x != next) {
                     @SuppressWarnings("unchecked") V vv = (V)x;
                     nextValue = vv;
                     break;
@@ -3070,7 +3070,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != sentinel()) {
+                    if (x != null && x != next) {
                         if (! inBounds(next.key, cmp))
                             next = null;
                         else {
@@ -3103,7 +3103,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != sentinel()) {
+                    if (x != null && x != next) {
                         if (tooHigh(next.key, cmp))
                             next = null;
                         else {
@@ -3122,7 +3122,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if (next == null)
                         break;
                     Object x = next.value;
-                    if (x != null && x != sentinel()) {
+                    if (x != null && x != next) {
                         if (tooLow(next.key, cmp))
                             next = null;
                         else {
@@ -3577,7 +3577,6 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
     // Unsafe mechanics
     private static final sun.misc.Unsafe U = sun.misc.Unsafe.getUnsafe();
     private static final long HEAD;
-    private static final Node SENTINEL = new Node(null);
     static {
         try {
             HEAD = U.objectFieldOffset
@@ -3585,9 +3584,5 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
         } catch (ReflectiveOperationException e) {
             throw new Error(e);
         }
-    }
-
-    private static Node sentinel() {
-        return SENTINEL;
     }
 }


### PR DESCRIPTION
Reverts google/j2objc#947: ConcurrentSkipListMapTest unit test fails with null pointer exception:
```
java.lang.NullPointerException
	at 0x000000010f705ea8 java.lang.Throwable.nativeFillInStackTrace() + 24
	at 0x000000010f6cdd05 java.lang.Exception.<init>() + 21
	at 0x000000010f6e5c15 java.lang.RuntimeException.<init>() + 21
	at 0x000000010f6e1b55 java.lang.NullPointerException.<init>() + 21
	at 0x000000010f289167 java.util.concurrent.ConcurrentSkipListMap.doRemove() + 39
	at 0x000000010f28b968 java.util.concurrent.ConcurrentSkipListMap.remove() + 40
	at 0x000000010f296a8f java.util.concurrent.ConcurrentSkipListMap$SubMap.clear() + 271
	at 0x000000010e9422fb jsr166.ConcurrentSkipListSubMapTest.testClear() + 75
```