### PR TITLE
Add watchOS simulator support

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -42,6 +42,11 @@ ARCH_BUILD_MACOSX_DIR = $(ARCH_BUILD_DIR)/macosx
 ARCH_LIB_MACOSX_DIR = $(ARCH_LIB_DIR)/macosx
 DIST_LIB_MACOSX_DIR = $(DIST_LIB_DIR)/macosx
 
+# Watchos library dirs.
+ARCH_BUILD_WATCH_DIR = $(ARCH_BUILD_DIR)/watchos
+ARCH_LIB_WATCH_DIR = $(ARCH_LIB_DIR)/watchos
+DIST_LIB_WATCH_DIR = $(DIST_LIB_DIR)/watchos
+
 # Appletv library dirs.
 ARCH_BUILD_TV_DIR = $(ARCH_BUILD_DIR)/appletvos
 ARCH_LIB_TV_DIR = $(ARCH_LIB_DIR)/appletvos
@@ -59,7 +64,7 @@ TVOS_AVAILABLE = \
   then echo "YES"; else echo "NO"; fi)
 
 ifndef J2OBJC_ARCHS
-J2OBJC_ARCHS = macosx iphone iphone64 watchv7k simulator simulator64
+J2OBJC_ARCHS = macosx iphone iphone64 watchv7k watchsimulator simulator simulator64
 ifeq ($(TVOS_AVAILABLE), YES)
 J2OBJC_ARCHS += appletvos appletvsimulator
 endif

--- a/scripts/sysroot_path.sh
+++ b/scripts/sysroot_path.sh
@@ -24,9 +24,10 @@ if [ $# -gt 0 ]; then
     --iphoneos ) SDK_TYPE=iPhoneOS ;;
     --iphonesimulator ) SDK_TYPE=iPhoneSimulator ;;
     --watchos ) SDK_TYPE=WatchOS ;;
+    --watchsimulator ) SDK_TYPE=WatchSimulator ;;
     --appletvos ) SDK_TYPE=AppleTVOS ;;
     --appletvsimulator ) SDK_TYPE=AppleTVSimulator ;;
-    * ) echo "usage: $0 [--iphoneos | --iphonesimulator | --watchos | --appletvos | --appletvsimulator]" && exit 1 ;;
+    * ) echo "usage: $0 [--iphoneos | --iphonesimulator | --watchos | --watchsimulator | --appletvos | --appletvsimulator]" && exit 1 ;;
   esac
 fi
 
@@ -55,6 +56,8 @@ if [ "x${SDK_PATH}" = "x" ]; then
     SDK_TYPE=iphonesimulator
   elif [ ${SDK_TYPE} == "watchos" ]; then
     SDK_TYPE=watchos
+  elif [ ${SDK_TYPE} == "watchsimulator" ]; then
+    SDK_TYPE=watchsimulator
   elif [ ${SDK_TYPE} == "appletvos" ]; then
     SDK_TYPE=appletvos
   elif [ ${SDK_TYPE} == "appletvsimulator" ]; then


### PR DESCRIPTION
Now (before changes from this PR) iOS jre_emul static library is still built with armv7k architecture. This slice should be a part of a separate watchOS jre_emul library that should also contain slice for watchsimulator sdk. Just like it has been done for tvOS.