### PR TITLE
When --nullability option enabled, generate constructors with __nonnu…

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/gen/TypeGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/TypeGenerator.java
@@ -284,6 +284,12 @@ public abstract class TypeGenerator extends AbstractSourceGenerator {
     String selector = nameTable.getMethodSelector(element);
     if (m.isConstructor()) {
       returnType = "instancetype";
+      // when supports nullability - set constructor as nonnull (in case it is not annotated already)
+      // AFAIK Java doesn't support nullable constructor right?
+      // helps to work better with Swift
+      if (this.options.nullability() && !ElementUtil.hasNullableAnnotation(element)) {
+        returnType = returnType + " __nonnull";
+      }
     } else if (selector.equals("hash")) {
       // Explicitly test hashCode() because of NSObject's hash return value.
       returnType = "NSUInteger";


### PR DESCRIPTION
Why?

Currently, all j2objc classes are generated with nullable constructors. So that in Swift, we have to use:

`var myInstance = MyClass()!`

 to let compiler know, that method instance is for sure not null. Because Java class instance AFAIK cannot never return null, it is safe to declare all constructors with __nonnull annotation.

This commit respects options of j2objc (only insert this annotation, when j2objc runs with --nullability and also checks, if is constructor not annotated by Java - in this case, the generated code is untouched.