### PR TITLE
IOSClass initialize issue

### DIFF
--- a/jre_emul/Classes/IOSClass.m
+++ b/jre_emul/Classes/IOSClass.m
@@ -612,6 +612,7 @@ static IOSClass *IOSClass_ArrayClassForName(NSString *name, NSUInteger index) {
 }
 
 IOSClass *IOSClass_forName_(NSString *className) {
+  IOSClass_initialize();
   (void)nil_chk(className);
   IOSClass *iosClass = nil;
   if ([className length] > 0) {
@@ -634,6 +635,7 @@ IOSClass *IOSClass_forName_(NSString *className) {
 
 IOSClass *IOSClass_forName_initialize_classLoader_(
     NSString *className, jboolean load, JavaLangClassLoader *loader) {
+  IOSClass_initialize();
   return IOSClass_forName_(className);
 }
 


### PR DESCRIPTION
Hi team,

I found one issue, failure of Class.forName() for a class has package prefix.

I investigated this and finally I could find the root cause.
That is, IOSClass_initialize() is not called at the top of the static methods of java.lang.Class (IOSClass).
I guess IOSClass_initialize() should be called, because other translated code includes such code.

Could you please review this ?

I created two commits. The one is to reproduce the issue, and the other one is the fix.