### PR TITLE
Add support for Character unboxing on cast

### DIFF
--- a/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/AutoboxerTest.java
@@ -443,6 +443,83 @@ public class AutoboxerTest extends GenerationTest {
         "JreAssert(i == 0, JavaLangInteger_valueOfWithInt_(i));");
   }
 
+  public void testCharacterWrapperCastToPrimitive() throws IOException {
+    String translation =
+        translateSourceFile(
+            "class Test { "
+                + "char test1(Character toChar) { return (char) toChar; } "
+                + "int test2(Character toInt) { return (int) toInt; } "
+                + "long test3(Character toLong) { return (long) toLong; } "
+                + "float test4(Character toFlt) { return (float) toFlt; } "
+                + "double test5(Character toDbl) { return (double) toDbl; } }",
+            "Test",
+            "Test.m");
+
+    assertTranslation(translation, "return [((JavaLangCharacter *) nil_chk(toChar)) charValue];");
+    assertTranslation(
+        translation, "return (jint) [((JavaLangCharacter *) nil_chk(toInt)) charValue];");
+    assertTranslation(
+        translation, "return (jlong) [((JavaLangCharacter *) nil_chk(toLong)) charValue];");
+    assertTranslation(
+        translation, "return (jfloat) [((JavaLangCharacter *) nil_chk(toFlt)) charValue];");
+    assertTranslation(
+        translation, "return (jdouble) [((JavaLangCharacter *) nil_chk(toDbl)) charValue];");
+  }
+
+  public void testCharacterUnboxingAutoReboxing() throws IOException {
+    String translation =
+        translateSourceFile(
+            "class Test { "
+                + "void test() { "
+                + "Character toChar = 'A', toInt = 'A', toLong = 'A', toFlt = 'A', toDbl = 'A'; "
+                + "Object[] arr = "
+                + "{(char) toChar, (int) toInt, (long) toLong, (float) toFlt, (double) toDbl}; } }",
+            "Test",
+            "Test.m");
+
+    assertTranslation(
+        translation,
+        "IOSObjectArray *arr = [IOSObjectArray arrayWithObjects:(id[]){ "
+            + "JavaLangCharacter_valueOfWithChar_([toChar charValue]), "
+            + "JavaLangInteger_valueOfWithInt_((jint) [toInt charValue]), "
+            + "JavaLangLong_valueOfWithLong_((jlong) [toLong charValue]), "
+            + "JavaLangFloat_valueOfWithFloat_((jfloat) [toFlt charValue]),"
+            + " JavaLangDouble_valueOfWithDouble_((jdouble) [toDbl charValue]) }"
+            + " count:5 type:NSObject_class_()];");
+  }
+
+  public void testCharacterWrapperWithParamOverloading() throws IOException {
+    String translation =
+        translateSourceFile(
+            "class Test { "
+                + "void f(char i) {} void f(int i) {} void f(long l) {} "
+                + "void f(float f) {} void f(double d) {} "
+                + "void test1(Character toChar1) { f(toChar1); } "
+                + "void test2(Character toChar2) { f((char) toChar2); } "
+                + "void test3(Character toInt) { f((int) toInt); } "
+                + "void test4(Character toLong) { f((long) toLong); } "
+                + "void test5(Character toFlt) { f((float) toFlt); } "
+                + "void test6(Character toDbl) { f((double) toDbl); } }",
+            "Test",
+            "Test.m");
+
+    assertTranslation(
+        translation, "[self fWithChar:[((JavaLangCharacter *) nil_chk(toChar1)) charValue]]");
+    assertTranslation(
+        translation, "[self fWithChar:[((JavaLangCharacter *) nil_chk(toChar2)) charValue]];");
+    assertTranslation(
+        translation, "[self fWithInt:(jint) [((JavaLangCharacter *) nil_chk(toInt)) charValue]];");
+    assertTranslation(
+        translation,
+        "[self fWithLong:(jlong) [((JavaLangCharacter *) nil_chk(toLong)) charValue]];");
+    assertTranslation(
+        translation,
+        "[self fWithFloat:(jfloat) [((JavaLangCharacter *) nil_chk(toFlt)) charValue]];");
+    assertTranslation(
+        translation,
+        "[self fWithDouble:(jdouble) [((JavaLangCharacter *) nil_chk(toDbl)) charValue]];");
+  }
+
   public void testNonWrapperObjectTypeCastToPrimitive() throws IOException {
     String translation = translateSourceFile(
         "class Test { int test(Object o) { return (int) o; } "


### PR DESCRIPTION
Casting java.lang.Character to a primitive currently attempts to cast it directly into its boxed type (as is done with Object types), which will fail in runtime and is inconsistent with java.

According to the JLS:
"Assignment contexts allow the use of ... an unboxing conversion optionally followed by a widening primitive conversion"

Character is the only source for such Unboxing+widening conversions that is not a Number, and it converts to int, long, float and double.

This commit adds a special casing for Character, on top of the existning case for Number conversions.