### PR TITLE
Load the java rules from @rules_java repository.

### DIFF
--- a/BUILD.dist
+++ b/BUILD.dist
@@ -12,6 +12,8 @@
 
 licenses(["notice"])  # Apache License 2.0
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 exports_files(["LICENSE"])
 
 package(

--- a/WORKSPACE.dist
+++ b/WORKSPACE.dist
@@ -12,3 +12,26 @@
 
 # The presence of thie WORKSPACE file in the J2ObjC distribution makes it
 # accessible as a Bazel repository.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_java",
+    sha256 = "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+    strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+        "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+    ],
+)
+
+ # Needed only because of java_tools.
+http_archive(
+    name = "rules_cc",
+    sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+    ],
+)

--- a/examples/Contacts/BUILD.bazel
+++ b/examples/Contacts/BUILD.bazel
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@rules_java//java:defs.bzl", "java_library")
 
 ios_application(
     name = "Contacts",


### PR DESCRIPTION
This change is required before flipping --incompatible_load_java_rules_from_bzl in Bazel (see bazelbuild/bazel#8746)