### PR TITLE
Fix jar template issue in xalan build

### DIFF
--- a/jre_emul/java.mk
+++ b/jre_emul/java.mk
@@ -27,6 +27,8 @@ ALL_JAVA_SOURCES = $(JAVA_SOURCES) $(NO_TRANSLATE_JAVA_SOURCES)
 
 ANNOTATIONS_JAR = $(DIST_JAR_DIR)/j2objc_annotations.jar
 
+MKTEMP_DIR = j2objc-jre_emul
+
 clean:
 	@rm -f $(EMULATION_JAR_DIST) $(EMULATION_SRC_JAR_DIST)
 
@@ -55,14 +57,6 @@ $(EMULATION_MODULE_DIST): $(EMULATION_MODULE)
 $(EMULATION_SRC_JAR_DIST): $(EMULATION_SRC_JAR)
 	@mkdir -p $(@D)
 	@install -m 0644 $< $@
-
-# The following test returns true on Linux or with GNU tools installed,
-# otherwise false on macOS which uses the BSD version.
-ifeq ($(shell mktemp --version >/dev/null 2>&1 && echo GNU || echo BSD), GNU)
-MKTEMP_CMD = mktemp -d --tmpdir j2objc-jre_emul.XXXXXX
-else
-MKTEMP_CMD = mktemp -d -t j2objc-jre_emul
-endif
 
 $(EMULATION_JAR): $(ALL_JAVA_SOURCES)
 	@mkdir -p $(@D)

--- a/make/common.mk
+++ b/make/common.mk
@@ -100,6 +100,14 @@ LIBTOOL = libtool
 LIPO = lipo
 endif
 
+# The following test returns true on Linux or with GNU tools installed,
+# otherwise false on macOS which uses the BSD version.
+ifeq ($(shell mktemp --version >/dev/null 2>&1 && echo GNU || echo BSD), GNU)
+MKTEMP_CMD = mktemp -d --tmpdir $(MKTEMP_DIR).XXXXXX
+else
+MKTEMP_CMD = mktemp -d -t $(MKTEMP_DIR)
+endif
+
 ifndef CONFIGURATION_BUILD_DIR
 # Determine this makefile's path.
 SYSROOT_SCRIPT := $(J2OBJC_ROOT)/scripts/sysroot_path.sh

--- a/xalan/Makefile
+++ b/xalan/Makefile
@@ -62,6 +62,8 @@ fat_lib_dependencies: jre_emul_dist
 JAR = $(BUILD_DIR)/j2objc_xalan.jar
 DIST_JAR = $(DIST_JAR_DIR)/j2objc_xalan.jar
 
+MKTEMP_DIR = j2objc-xalan
+
 XALAN_LICENSE = NOTICE
 XALAN_LICENSE_DIST = $(DIST_LICENSE_DIR)/apache_xalan_license.txt
 
@@ -81,7 +83,7 @@ java: $(DIST_JAR)
 
 $(JAR): $(JAVA_SOURCES) | $(BUILD_DIR) java_deps_dist annotations_dist
 	@echo "building j2objc_xalan.jar"
-	@stage_dir=`mktemp -d -t j2objc-xalan`; \
+	@stage_dir=`${MKTEMP_CMD}`; \
 	$(JAVAC) -sourcepath $(SOURCEPATH) -encoding UTF-8 \
 	    -cp $(DIST_JAR_DIR)/j2objc_annotations.jar -d $$stage_dir \
 	    -source 1.7 -target 1.7 -bootclasspath $(DIST_JAR_DIR)/jre_emul.jar $^; \


### PR DESCRIPTION
Fixes this problem when building j2objc on a Mac:

```
Building libxalan.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo -create /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/objs-appletvos/libxalan.a /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/objs-appletvsimulator/libxalan.a -output /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/appletvos/libxalan.a
building j2objc_xalan.jar
mktemp: too few X's in template ‘j2objc-xalan’
```