### PR TITLE
Added "timezone" reserved word from /usr/include/time.h.

### DIFF
--- a/translator/src/main/resources/com/google/devtools/j2objc/reserved_names.txt
+++ b/translator/src/main/resources/com/google/devtools/j2objc/reserved_names.txt
@@ -166,7 +166,7 @@ EXC_MASK_CORPSE_NOTIFY EXC_MASK_ALL FIRST_EXCEPTION EXC_SOFT_SIGNAL EXC_MACF_MIN
 EXC_MACF_MAX
 
 # Definitions from time.h
-daylight getdate_err tzname
+daylight getdate_err timezone tzname
 
 # Definitions from types.h
 S_IRGRP S_IROTH S_IRUSR S_IRWXG S_IRWXO S_IRWXU S_IWGRP S_IWOTH


### PR DESCRIPTION
Xcode 11's SDKs updated /usr/include/time.h with a "timezone" #define, so it needs to be added to j2objc's reserved words list.