### PR TITLE
Reformatting time.format.tests

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatter.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatter.java
@@ -354,8 +354,9 @@ public class TCKDateTimeFormatter {
                 {ThaiBuddhistChronology.INSTANCE, ZONE_PARIS, thaiZdt, "2551:11:+02:00:Europe/Paris:ThaiBuddhist"},
                 {IsoChronology.INSTANCE, ZONE_PARIS, thaiZdt, "2008:11:+02:00:Europe/Paris:ISO"},
         };
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test
     @UseDataProvider("data_format_withZone_withChronology")
     public void test_format_withZone_withChronology(Chronology overrideChrono, ZoneId overrideZone, TemporalAccessor temporal, String expected) {

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatter.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatter.java
@@ -116,7 +116,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatter.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKDateTimeFormatter {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java
@@ -91,7 +91,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatterBuilder.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKDateTimeFormatterBuilder {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatters.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatters.java
@@ -1157,8 +1157,9 @@ public class TCKDateTimeFormatters {
                 throw new UnsupportedOperationException();
             }
         };
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test
     @UseDataProvider("weekDate")
     public void test_print_isoWeekDate(TemporalAccessor test, String expected) {

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatters.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeFormatters.java
@@ -111,7 +111,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatter.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKDateTimeFormatters {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeParseResolver.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeParseResolver.java
@@ -132,7 +132,6 @@ import org.junit.Test;
 /**
  * Test parse resolving.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKDateTimeParseResolver {
     // TODO: tests with weird TenporalField implementations

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeParseResolver.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeParseResolver.java
@@ -935,8 +935,9 @@ public class TCKDateTimeParseResolver {
         assertEquals(accessor.query(TemporalQueries.localDate()), LocalDate.of(1970, 1, 3));
         assertEquals(accessor.query(TemporalQueries.localTime()), null);
         assertEquals(accessor.query(TemporalQueries.chronology()), MinguoChronology.INSTANCE);
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test
     public void test_withChronology_parsedChronology_noOverride() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().parseDefaulting(EPOCH_DAY, 2).appendChronologyId().toFormatter();
@@ -944,8 +945,9 @@ public class TCKDateTimeParseResolver {
         assertEquals(accessor.query(TemporalQueries.localDate()), LocalDate.of(1970, 1, 3));
         assertEquals(accessor.query(TemporalQueries.localTime()), null);
         assertEquals(accessor.query(TemporalQueries.chronology()), ThaiBuddhistChronology.INSTANCE);
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test
     public void test_withChronology_parsedChronology_override() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().parseDefaulting(EPOCH_DAY, 2).appendChronologyId().toFormatter();
@@ -1027,15 +1029,17 @@ public class TCKDateTimeParseResolver {
         assertEquals(accessor.query(TemporalQueries.localDate()), LocalDate.from(mdt));
         assertEquals(accessor.query(TemporalQueries.localTime()), null);
         assertEquals(accessor.query(TemporalQueries.chronology()), MinguoChronology.INSTANCE);
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test(expected = DateTimeParseException.class)
     public void test_fieldResolvesToChronoLocalDate_noOverrideChrono_wrongChrono() {
         ChronoLocalDate cld = ThaiBuddhistChronology.INSTANCE.dateNow();
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(new ResolvingField(cld)).toFormatter();
         f.parse("1234567890");
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test(expected = DateTimeParseException.class)
     public void test_fieldResolvesToChronoLocalDate_overrideChrono_wrongChrono() {
         ChronoLocalDate cld = ThaiBuddhistChronology.INSTANCE.dateNow();
@@ -1106,15 +1110,17 @@ public class TCKDateTimeParseResolver {
         assertEquals(accessor.query(TemporalQueries.localTime()), LocalTime.NOON);
         assertEquals(accessor.query(TemporalQueries.chronology()), MinguoChronology.INSTANCE);
         assertEquals(accessor.query(TemporalQueries.zoneId()), EUROPE_PARIS);
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test(expected = DateTimeParseException.class)
     public void test_fieldResolvesToChronoZonedDateTime_noOverrideChrono_wrongChrono() {
         ChronoZonedDateTime<?> cldt = ThaiBuddhistChronology.INSTANCE.dateNow().atTime(LocalTime.NOON).atZone(EUROPE_PARIS);
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(new ResolvingField(cldt)).toFormatter();
         f.parse("1234567890");
-    }
+    } */
 
+    /* J2ObjC removed: Only "gregorian" and "julian" calendars are supported.
     @Test(expected = DateTimeParseException.class)
     public void test_fieldResolvesToChronoZonedDateTime_overrideChrono_wrongChrono() {
         ChronoZonedDateTime<?> cldt = ThaiBuddhistChronology.INSTANCE.dateNow().atTime(LocalTime.NOON).atZone(EUROPE_PARIS);

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeTextPrinting.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDateTimeTextPrinting.java
@@ -84,7 +84,6 @@ import org.junit.Test;
 /**
  * Test text printing.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKDateTimeTextPrinting {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDecimalStyle.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKDecimalStyle.java
@@ -71,7 +71,6 @@ import org.junit.Test;
 /**
  * Test DecimalStyle.
  */
-
 public class TCKDecimalStyle {
 
     @Test

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKFormatStyle.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKFormatStyle.java
@@ -77,7 +77,6 @@ import org.junit.Test;
 /**
  * Test.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKFormatStyle {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKInstantPrinterParser.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKInstantPrinterParser.java
@@ -81,7 +81,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatterBuilder.appendInstant().
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKInstantPrinterParser {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKLocalizedFieldParser.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKLocalizedFieldParser.java
@@ -80,7 +80,6 @@ import test.java.time.format.AbstractTestPrinterParser;
 /**
  * Test TCKLocalizedFieldParser.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKLocalizedFieldParser extends AbstractTestPrinterParser {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKLocalizedFieldPrinter.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKLocalizedFieldPrinter.java
@@ -77,7 +77,6 @@ import test.java.time.format.AbstractTestPrinterParser;
 /**
  * Test LocalizedFieldPrinterParser.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKLocalizedFieldPrinter extends AbstractTestPrinterParser {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKOffsetPrinterParser.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKOffsetPrinterParser.java
@@ -80,7 +80,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatterBuilder.appendOffset().
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKOffsetPrinterParser {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKPadPrinterParser.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKPadPrinterParser.java
@@ -79,7 +79,6 @@ import org.junit.Test;
 /**
  * Test padding behavior of formatter.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKPadPrinterParser {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKResolverStyle.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKResolverStyle.java
@@ -79,7 +79,6 @@ import org.junit.Test;
 /**
  * Test.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKResolverStyle {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKSignStyle.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKSignStyle.java
@@ -77,7 +77,6 @@ import org.junit.Test;
 /**
  * Test.
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKSignStyle {
 

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKTextStyle.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKTextStyle.java
@@ -69,7 +69,6 @@ import org.junit.Test;
 /**
  * Test DecimalStyle.
  */
-
 public class TCKTextStyle {
 
     @Test

--- a/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKZoneIdPrinterParser.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/test/java/time/tck/java/time/format/TCKZoneIdPrinterParser.java
@@ -85,7 +85,6 @@ import org.junit.Test;
 /**
  * Test DateTimeFormatterBuilder.appendZoneId().
  */
-
 @RunWith(DataProviderRunner.class)
 public class TCKZoneIdPrinterParser {
 


### PR DESCRIPTION
Removing empty line between doc-comment and annotation
Comment each test case on an individual basis. 
Before one comment was being used to comment out consecutive tests that used calendars different from julian or gregorian. Now individual comments are used to make more clear the intended behavior.
