### PR TITLE
updated VMStack to function closely to current android version.

### DIFF
--- a/jre_emul/Classes/dalvik/system/VMStack.java
+++ b/jre_emul/Classes/dalvik/system/VMStack.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2007 The Android Open Source Project
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,11 +15,126 @@
 
 package dalvik.system;
 
+import android.compat.annotation.UnsupportedAppUsage;
+
 /**
- * Stubbed version of Android's VMStack.
+ * Stub implementation of dalvik.system.VMStack.
  */
+
+/**
+ * Provides a limited interface to the Dalvik VM stack. This class is mostly
+ * used for implementing security checks.
+ *
+ * @hide
+ */
+@libcore.api.CorePlatformApi
+
 public final class VMStack {
+  private VMStack() {
+  }
+
+  /**
+   * Stub implementation of getCallingClassLoader()
+   *
+   *  Returns the defining class loader of the caller's caller.
+   *
+   * @return the requested class loader, or {@code null} if this is the
+   * bootstrap class loader.
+   * @deprecated Use {@code ClassLoader.getClassLoader(sun.reflect.Reflection.getCallerClass())}.
+   * Note that that can return {@link BootClassLoader} on Android where the RI
+   * would have returned null.
+   */
   public static ClassLoader getCallingClassLoader() {
     return null;
+  }
+
+  /**
+   * Returns the class of the caller's caller.
+   *
+   * @return the requested class, or {@code null}.
+   * @deprecated Use {@link sun.reflect.Reflection#getCallerClass()}.
+   */
+  @Deprecated
+  public static Class<?> getStackClass1() throws ClassNotFoundException {
+    return getStackClass2();
+  }
+
+  /**
+   * Implementation unique to J2ObjC
+   *
+   * Returns the class of the caller's caller's caller.
+   *
+   * @return the requested class, or {@code null}.
+   */
+  @UnsupportedAppUsage
+  public static Class<?> getStackClass2() throws ClassNotFoundException {
+    // This method (getCallerClass()) constitutes another stack frame,
+    // so we need to get stack class 2 rather than get stack class 1.
+    try {
+      StackTraceElement[] stack = new Throwable().getStackTrace();
+      return Class.forName(stack[2].getClassName());
+    } catch (ClassNotFoundException e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Stub implementation of getClosestUserClassLoader()
+   *
+   * Returns the first ClassLoader on the call stack that isn't the
+   * bootstrap class loader.
+   */
+  public static ClassLoader getClosestUserClassLoader() {
+    return null;
+  }
+
+  /**
+   * Implementation unique to J2ObjC
+   *
+   * Retrieves the stack trace from the specified thread.
+   *
+   * @param t thread of interest
+   * @return an array of stack trace elements, or null if the thread
+   * doesn't have a stack trace (e.g. because it exited)
+   */
+  @UnsupportedAppUsage
+  public static StackTraceElement[] getThreadStackTrace(Thread t) {
+    return t.getStackTrace();
+  }
+
+  /**
+   * Cannot be implemented in J2ObjC
+   *
+   * Retrieves an annotated stack trace from the specified thread.
+   *
+   * @param t thread of interest
+   * @return an array of annotated stack frames, or null if the thread
+   * doesn't have a stack trace (e.g. because it exited)
+   *
+   @libcore.api.CorePlatformApi
+   @FastNative
+   native public static AnnotatedStackTraceElement[]
+   getAnnotatedThreadStackTrace(Thread t);
+   */
+
+  /**
+   * Implementation unique to J2ObjC
+   *
+   * Retrieves a partial stack trace from the specified thread into
+   * the provided array.
+   *
+   * @param t thread of interest
+   * @param stackTraceElements preallocated array for use when only the top of stack is
+   * desired. Unused elements will be filled with null values.
+   * @return the number of elements filled
+   */
+  @UnsupportedAppUsage
+  public static int fillStackTraceElements(Thread t,
+                                           StackTraceElement[] stackTraceElements) {
+    StackTraceElement[] stackTrace = t.getStackTrace();
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      stackTraceElements[i] = stackTrace[i];
+    }
+    return stackTraceElements.length;
   }
 }

--- a/jre_emul/jre_sources.mk
+++ b/jre_emul/jre_sources.mk
@@ -563,6 +563,7 @@ JAVA_PRIVATE_SOURCES_CORE = \
   dalvik/system/BlockGuard.java \
   dalvik/system/CloseGuard.java \
   dalvik/system/VersionCodes.java \
+  dalvik/system/VMStack.java \
   java/io/EmulatedFields.java \
   java/io/EmulatedFieldsForDumping.java \
   java/io/EmulatedFieldsForLoading.java \


### PR DESCRIPTION
Updated VMStack to function closely to current android version These methods were changed the most: getStackClass2(), getThreadeStackTrace(), fillStackTraceElements(). This implementation was chosen due to repeated call of these methods in the current version of android. 