### PR TITLE
updated reflection.java

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/sun/reflect/Reflection.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/sun/reflect/Reflection.java
@@ -30,16 +30,31 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import dalvik.system.VMStack;
+
 /** Common utility routines used by both java.lang and
-    java.lang.reflect */
+ java.lang.reflect */
 
 public class Reflection {
 
-    public static void ensureMemberAccess(Class currentClass,
-                                          Class memberClass,
+
+    /**
+     * @return Returns the class of the caller of the method calling this method,
+     *      ignoring frames associated with java.lang.reflect.Method.invoke()
+     *      and its implementation
+     * @throws ClassNotFoundException
+     */
+    public static Class<?> getCallerClass() throws ClassNotFoundException {
+        // This method (getCallerClass()) constitutes another stack frame,
+        // so we need to call getStackClass2() rather than getStackClass1().
+        return VMStack.getStackClass2();
+    }
+
+    public static void ensureMemberAccess(Class<?> currentClass,
+                                          Class<?> memberClass,
                                           Object target,
                                           int modifiers)
-        throws IllegalAccessException
+            throws IllegalAccessException
     {
         if (currentClass == null || memberClass == null) {
             throw new InternalError();
@@ -47,18 +62,18 @@ public class Reflection {
 
         if (!verifyMemberAccess(currentClass, memberClass, target, modifiers)) {
             throw new IllegalAccessException("Class " + currentClass.getName() +
-                                             " can not access a member of class " +
-                                             memberClass.getName() +
-                                             " with modifiers \"" +
-                                             Modifier.toString(modifiers) +
-                                             "\"");
+                    " can not access a member of class " +
+                    memberClass.getName() +
+                    " with modifiers \"" +
+                    Modifier.toString(modifiers) +
+                    "\"");
         }
     }
 
-    public static boolean verifyMemberAccess(Class currentClass,
+    public static boolean verifyMemberAccess(Class<?> currentClass,
                                              // Declaring class of field
                                              // or method
-                                             Class  memberClass,
+                                             Class<?>  memberClass,
                                              // May be NULL in case of statics
                                              Object target,
                                              int    modifiers)
@@ -78,7 +93,7 @@ public class Reflection {
         /* ----- BEGIN j2objc -----
         if (!Modifier.isPublic(getClassAccessFlags(memberClass))) {*/
         if (!Modifier.isPublic(memberClass.getModifiers())) {
-        // ----- END android -----
+            // ----- END android -----
             isSameClassPackage = isSameClassPackage(currentClass, memberClass);
             gotIsSameClassPackage = true;
             if (!isSameClassPackage) {
@@ -104,7 +119,7 @@ public class Reflection {
         if (!successSoFar && !Modifier.isPrivate(modifiers)) {
             if (!gotIsSameClassPackage) {
                 isSameClassPackage = isSameClassPackage(currentClass,
-                                                        memberClass);
+                        memberClass);
                 gotIsSameClassPackage = true;
             }
 
@@ -119,7 +134,7 @@ public class Reflection {
 
         if (Modifier.isProtected(modifiers)) {
             // Additional test for protected members: JLS 6.6.2
-            Class targetClass = (target == null ? memberClass : target.getClass());
+            Class<?> targetClass = (target == null ? memberClass : target.getClass());
             if (targetClass != currentClass) {
                 if (!gotIsSameClassPackage) {
                     isSameClassPackage = isSameClassPackage(currentClass, memberClass);
@@ -136,13 +151,13 @@ public class Reflection {
         return true;
     }
 
-    private static boolean isSameClassPackage(Class c1, Class c2) {
+    private static boolean isSameClassPackage(Class<?> c1, Class<?> c2) {
         return isSameClassPackage(c1.getClassLoader(), c1.getName(),
-                                  c2.getClassLoader(), c2.getName());
+                c2.getClassLoader(), c2.getName());
     }
 
     /** Returns true if two classes are in the same package; classloader
-        and classname information is enough to determine a class's package */
+     and classname information is enough to determine a class's package */
     private static boolean isSameClassPackage(ClassLoader loader1, String name1,
                                               ClassLoader loader2, String name2)
     {
@@ -191,8 +206,8 @@ public class Reflection {
         }
     }
 
-    static boolean isSubclassOf(Class queryClass,
-                                Class ofClass)
+    static boolean isSubclassOf(Class<?> queryClass,
+                                Class<?> ofClass)
     {
         while (queryClass != null) {
             if (queryClass == ofClass) {


### PR DESCRIPTION
reverted getCallerClass() to refly on VMStack to avoid repeated code and minimize differences between J2ObjC and android