### PR TITLE
fix getCallerClass in concurrent.atomic

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.java
@@ -102,8 +102,11 @@ public abstract class AtomicReferenceFieldUpdater<T,V> {
     public static <U,W> AtomicReferenceFieldUpdater<U,W> newUpdater(Class<U> tclass,
                                                                     Class<W> vclass,
                                                                     String fieldName) {
+        return new AtomicReferenceFieldUpdaterImpl<U,W>(tclass, vclass, fieldName, null);
+        /* J2ObjC: Call stack not available.
         return new AtomicReferenceFieldUpdaterImpl<U,W>
             (tclass, vclass, fieldName, Reflection.getCallerClass());
+        */
     }
 
     /**


### PR DESCRIPTION
commented out the use of getCallerClass in AtomicReferenceFieldUpdater, because the returned caller class name was only used for checkPackageAccess, while checkPackageAccess was removed in latest update due to "Skip checkPackageAccess which is a noop on Android."