### PR TITLE
Add support for the arm64 architecture for macOS

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -76,7 +76,7 @@ J2OBJC_ARCHS = $(subst _, ,$(ENV_J2OBJC_ARCHS))
 else
 # 32bit iPhone archs are no longer built by default. To build a release
 # with them, define J2OBJC_ARCHS with "iphone" and "simulator" included.
-J2OBJC_ARCHS = macosx iphone64 iphone64e watchv7k watch64 watchsimulator \
+J2OBJC_ARCHS = macosx macosx64 iphone64 iphone64e watchv7k watch64 watchsimulator \
     simulator64 maccatalyst
 ifeq ($(TVOS_AVAILABLE), YES)
 J2OBJC_ARCHS += appletvos appletvsimulator


### PR DESCRIPTION
Verified with:

```
> lipo -archs jre_emul/build_result/macosx/libjre_emul.a 
x86_64 arm64
```

Is anything else needed?