### PR TITLE
M1 support

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -85,7 +85,7 @@ else
 # 32bit iPhone archs are no longer built by default. To build a release
 # with them, define J2OBJC_ARCHS with "iphone" and "simulator" included.
 J2OBJC_ARCHS = macosx iphone64 iphone64e watchv7k watch64 watchsimulator \
-    simulator64 maccatalyst
+    simulator64 simulatora64 maccatalyst
 ifeq ($(TVOS_AVAILABLE), YES)
 J2OBJC_ARCHS += appletvos appletvsimulator
 endif

--- a/make/common.mk
+++ b/make/common.mk
@@ -35,12 +35,17 @@ ARCH_BIN_DIR = $(DIST_DIR)
 ARCH_LIB_DIR = $(DIST_LIB_DIR)
 ARCH_LIB_MACOSX_DIR = $(DIST_LIB_MACOSX_DIR)
 ARCH_LIB_MAC_CATALYST_DIR = $(DIST_LIB_MAC_CATALYST_DIR)
+ARCH_LIB_SIMULATOR_DIR = $(ARCH_LIB_SIMULATOR_DIR)
 ARCH_INCLUDE_DIR = $(DIST_INCLUDE_DIR)
 endif
 
 # iPhone-specific library dirs, used for xcframework.
 ARCH_BUILD_IPHONE_DIR = $(ARCH_BUILD_DIR)/iphone
+
+# iPhone simulator library dirs.
 ARCH_BUILD_SIMULATOR_DIR = $(ARCH_BUILD_DIR)/simulator
+ARCH_LIB_SIMULATOR_DIR = $(ARCH_LIB_DIR)/simulator
+DIST_LIB_SIMULATOR_DIR = $(DIST_LIB_DIR)/simulator
 
 # Macosx library dirs.
 ARCH_BUILD_MACOSX_DIR = $(ARCH_BUILD_DIR)/macosx
@@ -85,7 +90,7 @@ else
 # 32bit iPhone archs are no longer built by default. To build a release
 # with them, define J2OBJC_ARCHS with "iphone" and "simulator" included.
 J2OBJC_ARCHS = macosx iphone64 iphone64e watchv7k watch64 watchsimulator \
-    simulator64 simulatora64 maccatalyst
+    simulator simulator64 maccatalyst
 ifeq ($(TVOS_AVAILABLE), YES)
 J2OBJC_ARCHS += appletvos appletvsimulator
 endif

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -42,11 +42,9 @@ FAT_LIB_WATCH64_FLAGS = -arch arm64_32 -DJ2OBJC_BUILD_ARCH=arm64_32 -mwatchos-ve
   -isysroot $(FAT_LIB_WATCH_SDK_DIR)
 FAT_LIB_WATCHSIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -mwatchos-version-min=2.0 \
   -isysroot $(FAT_LIB_WATCHSIMULATOR_SDK_DIR)
-FAT_LIB_SIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -miphoneos-version-min=5.0 \
+FAT_LIB_SIMULATOR_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
-FAT_LIB_SIMULATOR64_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
-  -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
-FAT_LIB_SIMULATORA64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=12.0 \
+FAT_LIB_SIMULATOR64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=12.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 
 FAT_LIB_TV_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -mappletvos-version-min=9.0 \
@@ -95,11 +93,10 @@ arch_flags = $(strip \
   $(patsubst watchsimulator,$(FAT_LIB_WATCHSIMULATOR_FLAGS),\
   $(patsubst simulator,$(FAT_LIB_SIMULATOR_FLAGS),\
   $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),\
-  $(patsubst simulatora64,$(FAT_LIB_SIMULATORA64_FLAGS),\
   $(patsubst appletvos,$(FAT_LIB_TV_FLAGS),\
   $(patsubst appletvsimulator,$(FAT_LIB_TVSIMULATOR_FLAGS),\
   $(patsubst maccatalyst,$(FAT_LIB_MAC_CATALYST_FLAGS),\
-  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1)))))))))))))))))
+  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1))))))))))))))))
 
 fat_lib_dependencies:
 	@:

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -46,6 +46,8 @@ FAT_LIB_SIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -miphoneos-version
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 FAT_LIB_SIMULATOR64_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
+FAT_LIB_SIMULATORA64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=12.0 \
+  -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 
 FAT_LIB_TV_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -mappletvos-version-min=9.0 \
   -isysroot $(FAT_LIB_TV_SDK_DIR)
@@ -93,10 +95,11 @@ arch_flags = $(strip \
   $(patsubst watchsimulator,$(FAT_LIB_WATCHSIMULATOR_FLAGS),\
   $(patsubst simulator,$(FAT_LIB_SIMULATOR_FLAGS),\
   $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),\
+  $(patsubst simulatora64,$(FAT_LIB_SIMULATORA64_FLAGS),\
   $(patsubst appletvos,$(FAT_LIB_TV_FLAGS),\
   $(patsubst appletvsimulator,$(FAT_LIB_TVSIMULATOR_FLAGS),\
   $(patsubst maccatalyst,$(FAT_LIB_MAC_CATALYST_FLAGS),\
-  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1))))))))))))))))
+  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1)))))))))))))))))
 
 fat_lib_dependencies:
 	@:
@@ -267,7 +270,8 @@ emit_arch_specific_compile_rules = $(foreach arch,$(XCODE_ARCHS),\
 else
 # Targets specific to a command-line build
 
-FAT_LIB_IOS_ARCHS = $(filter-out macos% maccatalyst% appletv% watch%,$(J2OBJC_ARCHS))
+FAT_LIB_IOS_ARCHS = $(filter-out simulatora64 macos% maccatalyst% appletv% watch%,$(J2OBJC_ARCHS))
+FAT_LIB_SIMULATOR_ARCHS = $(filter simulator%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_ARCHS = $(filter macos%,$(J2OBJC_ARCHS))
 FAT_LIB_WATCH_ARCHS = $(filter watch%,$(J2OBJC_ARCHS))
 FAT_LIB_TV_ARCHS = $(filter appletv%,$(J2OBJC_ARCHS))
@@ -278,6 +282,9 @@ emit_library_rules = $(foreach arch,$(J2OBJC_ARCHS),\
   $(if $(FAT_LIB_IOS_ARCHS),\
     $(eval $(call fat_lib_rule,$(1),$(FAT_LIB_IOS_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_DIR)/lib$(1).a,) \
+  $(if $(FAT_LIB_SIMULATOR_ARCHS),\
+    $(eval $(call simulator_lib_rule,$(1),$(FAT_LIB_SIMULATOR_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
+    $(ARCH_BUILD_SIMULATOR_DIR)/lib$(1).a,) \
   $(if $(FAT_LIB_WATCH_ARCHS),\
     $(eval $(call watch_lib_rule,$(1),$(FAT_LIB_WATCH_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_WATCH_DIR)/lib$(1).a,) \

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -45,7 +45,7 @@ FAT_LIB_WATCHSIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -mwatchos-ver
 FAT_LIB_SIMULATOR_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 FAT_LIB_SIMULATOR64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=12.0 \
-  -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
+  -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR) --target=arm64-apple-ios-simulator
 
 FAT_LIB_TV_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -mappletvos-version-min=9.0 \
   -isysroot $(FAT_LIB_TV_SDK_DIR)
@@ -267,7 +267,7 @@ emit_arch_specific_compile_rules = $(foreach arch,$(XCODE_ARCHS),\
 else
 # Targets specific to a command-line build
 
-FAT_LIB_IOS_ARCHS = $(filter-out simulatora64 macos% maccatalyst% appletv% watch%,$(J2OBJC_ARCHS))
+FAT_LIB_IOS_ARCHS = $(filter-out simulator64 macos% maccatalyst% appletv% watch%,$(J2OBJC_ARCHS))
 FAT_LIB_SIMULATOR_ARCHS = $(filter simulator%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_ARCHS = $(filter macos%,$(J2OBJC_ARCHS))
 FAT_LIB_WATCH_ARCHS = $(filter watch%,$(J2OBJC_ARCHS))

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -24,7 +24,7 @@ FAT_LIB_WATCHSIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_pa
 FAT_LIB_TV_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvos)
 FAT_LIB_TVSIMULATOR_SDK_DIR := $(shell bash $(J2OBJC_ROOT)/scripts/sysroot_path.sh --appletvsimulator)
 
-FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -DJ2OBJC_BUILD_ARCH=x86_64 -mmacosx-version-min=10.7 \
+FAT_LIB_MACOSX_FLAGS = $(FAT_LIB_OSX_FLAGS) -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -mmacosx-version-min=10.7 \
   -isysroot $(FAT_LIB_MACOSX_SDK_DIR)
 FAT_LIB_MACOSX64_FLAGS = $(FAT_LIB_OSX_FLAGS) -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 \
   --target=arm64-apple-macos11 \

--- a/make/framework.mk
+++ b/make/framework.mk
@@ -91,7 +91,7 @@ DISALLOWED_WARNINGS = \
 VERIFY_FLAGS := -I$(FRAMEWORK_DIR)/Headers -I$(DIST_INCLUDE_DIR) \
   -Werror -Weverything $(DISALLOWED_WARNINGS)
 
-# As of Xcode 12, xcframeworks need single slice libraries, except for iOS and Mac platforms
+# As of Xcode 12, xcframeworks need single slice libraries, except for iOS, simulator and Mac platforms
 # which require fat libraries.
 FMWK_ARCH_LIBS = $(filter-out simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))
 FMWK_FAT_LIBS = $(filter simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))

--- a/make/framework.mk
+++ b/make/framework.mk
@@ -91,10 +91,10 @@ DISALLOWED_WARNINGS = \
 VERIFY_FLAGS := -I$(FRAMEWORK_DIR)/Headers -I$(DIST_INCLUDE_DIR) \
   -Werror -Weverything $(DISALLOWED_WARNINGS)
 
-# As of Xcode 12, xcframeworks need single slice libraries, except for Mac platforms
+# As of Xcode 12, xcframeworks need single slice libraries, except for iOS and Mac platforms
 # which require fat libraries.
-FMWK_ARCH_LIBS = $(filter-out macos% maccatalyst%,$(J2OBJC_ARCHS))
-FMWK_FAT_LIBS = $(filter macos% maccatalyst%,$(J2OBJC_ARCHS))
+FMWK_ARCH_LIBS = $(filter-out simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))
+FMWK_FAT_LIBS = $(filter simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))
 framework_libraries = \
   $(foreach arch,$(FMWK_ARCH_LIBS),$(wildcard $(BUILD_DIR)/objs-$(arch)*/lib$(1).a)) \
   $(foreach arch,$(FMWK_FAT_LIBS),$(wildcard $(BUILD_DIR)/$(arch)/lib$(1).a))


### PR DESCRIPTION
- Fixing building on M1 Mac (one note here, protobuf 3.11.1 doesn't exist for arm64, I used the latest in brew 3.15.8)
- Adding arm64 simulator
- Removing i386 simulator. Due to the way xcframeworks are built I renamed x86_64 to simulator and arm64 to simulator64. Alternatively you could keep them all and always build i386 as well.