### PR TITLE
Fix construction of xcframework architectures

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -57,6 +57,11 @@ ARCH_BUILD_WATCH_DIR = $(ARCH_BUILD_DIR)/watchos
 ARCH_LIB_WATCH_DIR = $(ARCH_LIB_DIR)/watchos
 DIST_LIB_WATCH_DIR = $(DIST_LIB_DIR)/watchos
 
+# AppleWatch simulator library dirs.
+ARCH_BUILD_WATCHSIMULATOR_DIR = $(ARCH_BUILD_DIR)/watchsimulator
+ARCH_LIB_WATCHSIMULATOR_DIR = $(ARCH_LIB_DIR)/watchsimulator
+DIST_LIB_WATCHSIMULATOR_DIR = $(DIST_LIB_DIR)/watchsimulator
+
 # Appletv library dirs.
 ARCH_BUILD_TV_DIR = $(ARCH_BUILD_DIR)/appletvos
 ARCH_LIB_TV_DIR = $(ARCH_LIB_DIR)/appletvos

--- a/make/common.mk
+++ b/make/common.mk
@@ -89,7 +89,7 @@ J2OBJC_ARCHS = $(subst _, ,$(ENV_J2OBJC_ARCHS))
 else
 # 32bit iPhone archs are no longer built by default. To build a release
 # with them, define J2OBJC_ARCHS with "iphone" and "simulator" included.
-J2OBJC_ARCHS = macosx iphone64 iphone64e watchv7k watch64 watchsimulator \
+J2OBJC_ARCHS = macosx iphone64 iphone64e watchosv7k watchos64 watchsimulator \
     simulator simulator64 maccatalyst
 ifeq ($(TVOS_AVAILABLE), YES)
 J2OBJC_ARCHS += appletvos appletvsimulator

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -224,6 +224,17 @@ $(ARCH_BUILD_WATCH_DIR)/lib$(1).a: $(2)
 	$$(LIPO) -create $$^ -output $$@
 endef
 
+# Generate the rule for the watchsimulator library
+# Args:
+#   1. Library name.
+#   2. List of architecture specific libraries.
+define watchsimulator_lib_rule
+$(ARCH_BUILD_WATCHSIMULATOR_DIR)/lib$(1).a: $(2)
+	@mkdir -p $$(@D)
+	$$(LIPO) -create $$^ -output $$@
+endef
+
+
 # Generate the rule for the appletv library
 # Args:
 #   1. Library name.
@@ -270,7 +281,8 @@ else
 FAT_LIB_IOS_ARCHS = $(filter iphone%,$(J2OBJC_ARCHS))
 FAT_LIB_SIMULATOR_ARCHS = $(filter simulator%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_ARCHS = $(filter macos%,$(J2OBJC_ARCHS))
-FAT_LIB_WATCH_ARCHS = $(filter watch%,$(J2OBJC_ARCHS))
+FAT_LIB_WATCH_ARCHS = $(filter watchos%,$(J2OBJC_ARCHS))
+FAT_LIB_WATCHSIMLATOR_ARCHS = $(filter watchsimulator%,$(J2OBJC_ARCHS))
 FAT_LIB_TV_ARCHS = $(filter appletv%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_CATALYST_ARCHS = $(filter maccatalyst%,$(J2OBJC_ARCHS))
 
@@ -285,6 +297,9 @@ emit_library_rules = $(foreach arch,$(J2OBJC_ARCHS),\
   $(if $(FAT_LIB_WATCH_ARCHS),\
     $(eval $(call watch_lib_rule,$(1),$(FAT_LIB_WATCH_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_WATCH_DIR)/lib$(1).a,) \
+  $(if $(FAT_LIB_WATCHSIMLATOR_ARCHS),\
+    $(eval $(call watchsimulator_lib_rule,$(1),$(FAT_LIB_WATCHSIMLATOR_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
+    $(ARCH_BUILD_WATCHSIMULATOR_DIR)/lib$(1).a,) \
   $(if $(FAT_LIB_MAC_ARCHS),\
     $(eval $(call mac_lib_rule,$(1),$(FAT_LIB_MAC_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_MACOSX_DIR)/lib$(1).a,) \

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -40,8 +40,12 @@ FAT_LIB_WATCHV7K_FLAGS = -arch armv7k -DJ2OBJC_BUILD_ARCH=armv7k -mwatchos-versi
   -isysroot $(FAT_LIB_WATCH_SDK_DIR)
 FAT_LIB_WATCH64_FLAGS = -arch arm64_32 -DJ2OBJC_BUILD_ARCH=arm64_32 -mwatchos-version-min=2.0 \
   -isysroot $(FAT_LIB_WATCH_SDK_DIR)
-FAT_LIB_WATCHSIMULATOR_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -mwatchos-version-min=2.0 \
+FAT_LIB_WATCHSIMULATORI386_FLAGS = -arch i386 -DJ2OBJC_BUILD_ARCH=i386 -mwatchos-version-min=2.0 \
   -isysroot $(FAT_LIB_WATCHSIMULATOR_SDK_DIR)
+FAT_LIB_WATCHSIMULATOR_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -mwatchos-version-min=6.1 \
+  -isysroot $(FAT_LIB_WATCHSIMULATOR_SDK_DIR)
+FAT_LIB_WATCHSIMULATOR64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -mwatchos-version-min=6.1 \
+  -isysroot $(FAT_LIB_WATCHSIMULATOR_SDK_DIR)  --target=arm64-apple-watchos-simulator
 FAT_LIB_SIMULATOR_FLAGS = -arch x86_64 -DJ2OBJC_BUILD_ARCH=x86_64 -miphoneos-version-min=5.0 \
   -isysroot $(FAT_LIB_SIMULATOR_SDK_DIR)
 FAT_LIB_SIMULATOR64_FLAGS = -arch arm64 -DJ2OBJC_BUILD_ARCH=arm64 -miphoneos-version-min=12.0 \
@@ -90,13 +94,15 @@ arch_flags = $(strip \
   $(patsubst iphone64e,$(FAT_LIB_IPHONE64E_FLAGS),\
   $(patsubst watchosv7k,$(FAT_LIB_WATCHV7K_FLAGS),\
   $(patsubst watchos64,$(FAT_LIB_WATCH64_FLAGS),\
+  $(patsubst watchsimulatori386,$(FAT_LIB_WATCHSIMULATORI386_FLAGS),\
   $(patsubst watchsimulator,$(FAT_LIB_WATCHSIMULATOR_FLAGS),\
+  $(patsubst watchsimulator64,$(FAT_LIB_WATCHSIMULATOR64_FLAGS),\
   $(patsubst simulator,$(FAT_LIB_SIMULATOR_FLAGS),\
   $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),\
   $(patsubst appletvos,$(FAT_LIB_TV_FLAGS),\
   $(patsubst appletvsimulator,$(FAT_LIB_TVSIMULATOR_FLAGS),\
   $(patsubst maccatalyst,$(FAT_LIB_MAC_CATALYST_FLAGS),\
-  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1))))))))))))))))
+  $(patsubst maccatalyst64,$(FAT_LIB_MAC_CATALYST64_FLAGS),$(1))))))))))))))))))
 
 fat_lib_dependencies:
 	@:

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -88,8 +88,8 @@ arch_flags = $(strip \
   $(patsubst iphone,$(FAT_LIB_IPHONE_FLAGS),\
   $(patsubst iphone64,$(FAT_LIB_IPHONE64_FLAGS),\
   $(patsubst iphone64e,$(FAT_LIB_IPHONE64E_FLAGS),\
-  $(patsubst watchv7k,$(FAT_LIB_WATCHV7K_FLAGS),\
-  $(patsubst watch64,$(FAT_LIB_WATCH64_FLAGS),\
+  $(patsubst watchosv7k,$(FAT_LIB_WATCHV7K_FLAGS),\
+  $(patsubst watchos64,$(FAT_LIB_WATCH64_FLAGS),\
   $(patsubst watchsimulator,$(FAT_LIB_WATCHSIMULATOR_FLAGS),\
   $(patsubst simulator,$(FAT_LIB_SIMULATOR_FLAGS),\
   $(patsubst simulator64,$(FAT_LIB_SIMULATOR64_FLAGS),\

--- a/make/fat_lib_macros.mk
+++ b/make/fat_lib_macros.mk
@@ -267,7 +267,7 @@ emit_arch_specific_compile_rules = $(foreach arch,$(XCODE_ARCHS),\
 else
 # Targets specific to a command-line build
 
-FAT_LIB_IOS_ARCHS = $(filter-out simulator64 macos% maccatalyst% appletv% watch%,$(J2OBJC_ARCHS))
+FAT_LIB_IOS_ARCHS = $(filter iphone%,$(J2OBJC_ARCHS))
 FAT_LIB_SIMULATOR_ARCHS = $(filter simulator%,$(J2OBJC_ARCHS))
 FAT_LIB_MAC_ARCHS = $(filter macos%,$(J2OBJC_ARCHS))
 FAT_LIB_WATCH_ARCHS = $(filter watch%,$(J2OBJC_ARCHS))
@@ -277,8 +277,8 @@ FAT_LIB_MAC_CATALYST_ARCHS = $(filter maccatalyst%,$(J2OBJC_ARCHS))
 emit_library_rules = $(foreach arch,$(J2OBJC_ARCHS),\
   $(eval $(call arch_lib_rule,$(BUILD_DIR)/objs-$(arch),$(1),$(2)))) \
   $(if $(FAT_LIB_IOS_ARCHS),\
-    $(eval $(call fat_lib_rule,$(1),$(FAT_LIB_IOS_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
-    $(ARCH_BUILD_DIR)/lib$(1).a,) \
+    $(eval $(call iphone_lib_rule,$(1),$(FAT_LIB_IOS_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
+    $(ARCH_BUILD_IPHONE_DIR)/lib$(1).a,) \
   $(if $(FAT_LIB_SIMULATOR_ARCHS),\
     $(eval $(call simulator_lib_rule,$(1),$(FAT_LIB_SIMULATOR_ARCHS:%=$(BUILD_DIR)/objs-%/lib$(1).a))) \
     $(ARCH_BUILD_SIMULATOR_DIR)/lib$(1).a,) \

--- a/make/framework.mk
+++ b/make/framework.mk
@@ -57,7 +57,6 @@ FRAMEWORK_PUBLIC_HEADERS = $(FRAMEWORK_HEADERS)
 endif
 
 FRAMEWORK_DIR = $(DIST_FRAMEWORK_DIR)/$(FRAMEWORK_NAME).xcframework
-STATIC_LIBRARY = $(BUILD_DIR)/lib$(STATIC_LIBRARY_NAME).a
 FRAMEWORK_HEADER = $(BUILD_DIR)/$(FRAMEWORK_NAME).h
 MODULE_MAP = $(BUILD_DIR)/module.modulemap
 
@@ -103,7 +102,7 @@ framework: dist $(FRAMEWORK_DIR) resources
 	@:
 
 # Create an xcframework from all appletv, iphone, maccatalyst, macosx, simulator and watchos libs.
-$(FRAMEWORK_DIR): $(STATIC_LIBRARY) $(FRAMEWORK_HEADER) $(MODULE_MAP)
+$(FRAMEWORK_DIR): $(FRAMEWORK_HEADER) $(MODULE_MAP)
 	@echo building $(FRAMEWORK_NAME) framework
 	@$(J2OBJC_ROOT)/scripts/gen_xcframework.sh $(FRAMEWORK_DIR) \
 			$(call framework_libraries,$(STATIC_LIBRARY_NAME))

--- a/make/framework.mk
+++ b/make/framework.mk
@@ -90,13 +90,10 @@ DISALLOWED_WARNINGS = \
 VERIFY_FLAGS := -I$(FRAMEWORK_DIR)/Headers -I$(DIST_INCLUDE_DIR) \
   -Werror -Weverything $(DISALLOWED_WARNINGS)
 
-# As of Xcode 12, xcframeworks need single slice libraries, except for iOS, simulator and Mac platforms
-# which require fat libraries.
-FMWK_ARCH_LIBS = $(filter-out simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))
-FMWK_FAT_LIBS = $(filter simulator% macos% maccatalyst%,$(J2OBJC_ARCHS))
+# As of Xcode 12, xcframeworks need a fat libraries for earch platform
+PLATFORMS = iphone simulator macos maccatalyst watchos watchsimulator appletvos appletvsimulator
 framework_libraries = \
-  $(foreach arch,$(FMWK_ARCH_LIBS),$(wildcard $(BUILD_DIR)/objs-$(arch)*/lib$(1).a)) \
-  $(foreach arch,$(FMWK_FAT_LIBS),$(wildcard $(BUILD_DIR)/$(arch)/lib$(1).a))
+  $(foreach platform,$(PLATFORMS),$(if $(findstring $(platform), $(J2OBJC_ARCHS)),$(wildcard $(BUILD_DIR)/$(platform)/lib$(1).a))) 
 
 framework: dist $(FRAMEWORK_DIR) resources
 	@:

--- a/scripts/gen_xcframework.sh
+++ b/scripts/gen_xcframework.sh
@@ -34,10 +34,7 @@ CMD="xcodebuild -create-xcframework -output "${FRAMEWORK_DIR}
 
 while test ${#} -gt 0
 do
-  # Skip libraries that have equivalent library definitions.
-  if [[ $1 != *"iphone64e"* ]] && [[ $1 != *"watchv7k"* ]]; then
-    CMD=${CMD}" -library "$1
-  fi
+  CMD=${CMD}" -library "$1
   shift
 done
 echo $CMD


### PR DESCRIPTION
This PR addresses some issues during the construction of the xcframework.

**Thin vs fat libraries**
When building the xcframework for each platform an own fat library has to be used. But for iphone, simulator, watchos, watchsimulator for each slice a thin library was used. That caused `xcodebuild -create-xcframework` complains with 
'Both x and y represent two equivalent library definitions.'

There was a workaround in `gen_xcframework` which just skipped the archs `iphone64e` and `watchv7k` and so they are also missing in the xcarchive. `watchv7k`is still required to upload a watchos app to app store.

**Missing archs**
For WatchOS the arches `x86_64` and `arm64` are not built. These are required to be able to run a WatchOS 6 or later app in a simulator. So current app watch apps are only able to be developed against a real device.


**Dependent changes**


**Fat library for iPhone moved to `dist/iphone`**
Currently all platforms has a own subfolder in `dist/[platform]` except for iPhone. It seems to me, that the intention was to have it too, because it was already prepared on same places. I changed that, because otherwise there are always exceptions needed. (e.g. finding the fat platform library for the xcframework)

**Fat library for iPhone/Simulator and WatchOs/Watchsimulator separated**
Before the fat library `dist/lib/libjre_emul.a` and `dist/lib/watchos/libjre_emul` contained architecture for the device and the simulator together. But because of introducing the arm64 simulator arches, they have to be separated. This was the reason why apple introduced the xcframeworks as well.

Together with the change before the new structure is:

- dist
  - lib
    - iphone
       - libjre_emul.a
    - simulator
       - libjre_emul.a
    - watchos
       - libjre_emul.a
    - watchsimulator 
       - libjre_emul.a

This has to be considered when linking the static libraries.

**Renamed watch architecture in `J2OBJC_ARCHS`**
Before `watchv7k` and `watch64` was used to configure the watchos targets via `J2OBJC_ARCHS`.
These were renamed to `watchosv7k` and `watchos64`. Otherwise it's hard to distinguish between `watch%` wand `watchsimulator%`.

The official architecture name is `watchos` anyway. And both notations was  inside the build scripts.


#1713 #1736 #1737 