### PR TITLE
Upgrade to oss-parent 9

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <version>9</version>
   </parent>
 
   <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
org.sonatype.oss:oss-parent:7 is unsigned (missing .asc files), which forces users of j2objc-annotations library
that enforce signature verification to explicitly allowlist oss-parent. Luckily oss-parent 9 is signed,
thus fixing this issue.

See:
https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/7/
vs
https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/9/