### PR TITLE
Removed "JDK 1.8" from the "Requirements" section of the "README.md" file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ code for their Android app, which they either own or are licensed to use.
 
 ## Requirements ##
 
-* JDK 1.8 or JDK 11 (see [announcement]
-  (https://groups.google.com/forum/#!topic/j2objc-discuss/BmDcAIvaTFs))
+* JDK 11
 * Mac workstation or laptop
 * OS X 10.12 or higher
 * Xcode 8 or higher


### PR DESCRIPTION
J2ObjC no longer builds with JDK 1.8. See Issue #2115 for details.