### PR TITLE
Change XCFramework artefact format to keep Xcode 15 happy

### DIFF
--- a/make/framework.mk
+++ b/make/framework.mk
@@ -99,13 +99,11 @@ $(FRAMEWORK_DIR): lib $(FRAMEWORK_HEADER) $(MODULE_MAP) | $(DIST_FRAMEWORK_DIR)
 	@mkdir -p $(FRAMEWORK_DIR)
 	@$(J2OBJC_ROOT)/scripts/gen_xcframework.sh $(FRAMEWORK_DIR) \
 		$(shell $(J2OBJC_ROOT)/scripts/list_framework_libraries.sh $(STATIC_LIBRARY_NAME))
-	@mkdir -p $(FRAMEWORK_DIR)/Versions/A/Headers
-	@/bin/ln -sfh A $(FRAMEWORK_DIR)/Versions/Current
-	@/bin/ln -sfh Versions/Current/Headers $(FRAMEWORK_DIR)/Headers
+	@mkdir -p $(FRAMEWORK_DIR)/Headers
 	@tar cf - -C $(STATIC_HEADERS_DIR) $(FRAMEWORK_HEADERS:$(STATIC_HEADERS_DIR)/%=%) \
-		| tar xfp - -C $(FRAMEWORK_DIR)/Versions/A/Headers
-	@install -m 0644 $(FRAMEWORK_HEADER) $(FRAMEWORK_DIR)/Versions/A/Headers
-	@install -m 0644 $(MODULE_MAP) $(FRAMEWORK_DIR)/Versions/A/Headers/
+		| tar xfp - -C $(FRAMEWORK_DIR)/Headers
+	@install -m 0644 $(FRAMEWORK_HEADER) $(FRAMEWORK_DIR)/Headers
+	@install -m 0644 $(MODULE_MAP) $(FRAMEWORK_DIR)/Headers/
 	@touch $@
 
 # Creates a framework "master" header file that includes all the framework's header files.


### PR DESCRIPTION
When building XCFramework artefacts, don't create Versions folder with Headers symlink; create real Headers folder instead