### PR TITLE
Now calling the `xcodebuild -create-xcframework` command with the `-headers` option

### DIFF
--- a/make/framework.mk
+++ b/make/framework.mk
@@ -96,14 +96,15 @@ framework:: lib $(FRAMEWORK_DIR) resources
 # Create an xcframework from all appletv, iphone, maccatalyst, macosx, simulator and watchos libs.
 $(FRAMEWORK_DIR): lib $(FRAMEWORK_HEADER) $(MODULE_MAP) | $(DIST_FRAMEWORK_DIR)
 	@echo building $(FRAMEWORK_NAME) framework
-	@mkdir -p $(FRAMEWORK_DIR)
-	@$(J2OBJC_ROOT)/scripts/gen_xcframework.sh $(FRAMEWORK_DIR) \
-		$(shell $(J2OBJC_ROOT)/scripts/list_framework_libraries.sh $(STATIC_LIBRARY_NAME))
+	@rm -rf ${FRAMEWORK_DIR}
 	@mkdir -p $(FRAMEWORK_DIR)/Headers
 	@tar cf - -C $(STATIC_HEADERS_DIR) $(FRAMEWORK_HEADERS:$(STATIC_HEADERS_DIR)/%=%) \
 		| tar xfp - -C $(FRAMEWORK_DIR)/Headers
 	@install -m 0644 $(FRAMEWORK_HEADER) $(FRAMEWORK_DIR)/Headers
 	@install -m 0644 $(MODULE_MAP) $(FRAMEWORK_DIR)/Headers/
+	@$(J2OBJC_ROOT)/scripts/gen_xcframework.sh $(FRAMEWORK_DIR) \
+		$(shell $(J2OBJC_ROOT)/scripts/list_framework_libraries.sh $(STATIC_LIBRARY_NAME))
+	@rm -rf ${FRAMEWORK_DIR}/Headers
 	@touch $@
 
 # Creates a framework "master" header file that includes all the framework's header files.

--- a/scripts/gen_xcframework.sh
+++ b/scripts/gen_xcframework.sh
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Build XCFramework framework from set of single-arch static libraries.
+# Build an XCFramework from a set of single-architecture static libraries.
 # xcodebuild -create-xcframework needs all libraries to be included
 # in a single command, so it can build the Info.plist listing them all.
 #
 # Usage:
-#   gen_xcframework.sh <output-directory> library [library ...]
+#   gen_xcframework.sh <output-directory> [static-library-path ...]
 
 if [ $# -lt 2 ]; then
   echo "usage: gen_xcframework.sh <output-directory> library [library ...]"
@@ -27,14 +27,18 @@ fi
 readonly FRAMEWORK_DIR=$1
 shift
 
-# xcodebuild won't override any existing framework files.
-rm -rf ${FRAMEWORK_DIR}/*
+readonly FRAMEWORK_HEADERS_DIR="${FRAMEWORK_DIR}/Headers"
+
+if [ ! -d "${FRAMEWORK_HEADERS_DIR}" ]; then
+  echo "$FRAMEWORK_HEADERS_DIR should exist but doesn't."
+fi
 
 CMD="xcodebuild -create-xcframework -output "${FRAMEWORK_DIR}
 
 while test ${#} -gt 0
 do
   CMD=${CMD}" -library "$1
+  CMD=${CMD}" -headers "$FRAMEWORK_HEADERS_DIR
   shift
 done
 echo $CMD


### PR DESCRIPTION
Updated the `make/framework.mk` and `scripts/gen_xcframework.sh` files so that the `xcodebuild -create-xcframework` command is called with the `-headers` option. Fixes #2180.