### PR TITLE
Fix "multiple commands produce 'module.modulemap'" error

### DIFF
--- a/make/framework.mk
+++ b/make/framework.mk
@@ -98,10 +98,11 @@ $(FRAMEWORK_DIR): lib $(FRAMEWORK_HEADER) $(MODULE_MAP) | $(DIST_FRAMEWORK_DIR)
 	@echo building $(FRAMEWORK_NAME) framework
 	@rm -rf ${FRAMEWORK_DIR}
 	@mkdir -p $(FRAMEWORK_DIR)/Headers
+	@mkdir -p $(FRAMEWORK_DIR)/Modules
 	@tar cf - -C $(STATIC_HEADERS_DIR) $(FRAMEWORK_HEADERS:$(STATIC_HEADERS_DIR)/%=%) \
 		| tar xfp - -C $(FRAMEWORK_DIR)/Headers
 	@install -m 0644 $(FRAMEWORK_HEADER) $(FRAMEWORK_DIR)/Headers
-	@install -m 0644 $(MODULE_MAP) $(FRAMEWORK_DIR)/Headers/
+	@install -m 0644 $(MODULE_MAP) $(FRAMEWORK_DIR)/Modules
 	@$(J2OBJC_ROOT)/scripts/gen_xcframework.sh $(FRAMEWORK_DIR) \
 		$(shell $(J2OBJC_ROOT)/scripts/list_framework_libraries.sh $(STATIC_LIBRARY_NAME))
 	@rm -rf ${FRAMEWORK_DIR}/Headers


### PR DESCRIPTION
Based on [that](https://github.com/google/j2objc/pull/2184) PR and its response, I've tried to link to other mentioned J2ObjC's XCFrameworks, but it caused "multiple commands produce 'module.modulemap'" error.  Also I hoped that I could add the JRE_Core XCFramework to an Xcode target without needing linking to any other of the J2ObjC XCFramework. I believed that JRE_Core XCFramework should be self-contained. Because of that I created [sample app](https://github.com/ale-gen/ModulemapErrorSampleApp) to show my problem. 

When I linked to another XCFramework produced by J2ObjC, I got the same situation like described in issue [#2185](https://github.com/google/j2objc/issues/2185). With changes added to this PR, I've noticed that in my case I don't have to link to another XCFramework, but if I do this, I also won't get modulemap error! It seems that currently modulemap file is located in wrong place.