### PR TITLE
Add ABSL_ROOT_DIR to build protobuf related tools in J2ObjC

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -281,8 +281,18 @@ check_protobuf_dir = $(error PROTOBUF_ROOT_DIR not defined)
 endif
 endif
 
+ifndef ABSL_ROOT_DIR
+ifndef IS_CLEAN_GOAL
+check_protobuf_dir = $(error ABSL_ROOT_DIR not defined)
+endif
+endif
+
+
 PROTOBUF_LIB_PATH = $(PROTOBUF_ROOT_DIR)/lib
 PROTOBUF_INCLUDE_PATH = $(PROTOBUF_ROOT_DIR)/include
+ABSL_LIB_PATH = $(ABSL_ROOT_DIR)/lib
+ABSL_INCLUDE_PATH = $(ABSL_ROOT_DIR)/include
+
 PROTOBUF_BIN_PATH = $(PROTOBUF_ROOT_DIR)/bin
 PROTOBUF_PROTOC = $(PROTOBUF_BIN_PATH)/protoc
 

--- a/protobuf/compiler/Makefile
+++ b/protobuf/compiler/Makefile
@@ -55,9 +55,9 @@ ABSL_LIBS = \
 	-l absl_spinlock_wait \
 	-l absl_strings
 
-CXXFLAGS = -x c++ -std=c++17 -stdlib=libc++ -Isrc -I$(PROTOBUF_INCLUDE_PATH) \
+CXXFLAGS = -x c++ -std=c++17 -stdlib=libc++ -Isrc -I$(PROTOBUF_INCLUDE_PATH) -I$(ABSL_INCLUDE_PATH) \
   -Wno-deprecated-declarations
-LDFLAGS = -L $(PROTOBUF_LIB_PATH) $(PROTOBUF_LIB) $(PROTOC_LIB) \
+LDFLAGS = -L $(PROTOBUF_LIB_PATH) -L $(ABSL_LIB_PATH) $(PROTOBUF_LIB) $(PROTOC_LIB) \
   $(ABSL_LIBS)
 
 dist: $(PROTOC_EXE_DIST) $(PROTOC_PLUGIN_DIST) $(DESCRIPTOR_PROTO_DIST)


### PR DESCRIPTION
It looks like that ABSL is not configured in the J2ObjC project. 

This pull request:
- defines ABSL_ROOT_DIR that points where ABSL lib is installed (similarly like with PROTOBUF_ROOT_DIR)
- updates Makefile to use this env to define include and lib dir