### PR TITLE
Setting Null-Reference on for originalBufferObject on MemoryRef

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/java/nio/DirectByteBuffer.java
@@ -120,7 +120,7 @@ public class DirectByteBuffer extends MappedByteBuffer implements DirectBuffer {
     @SuppressWarnings("unused")
     DirectByteBuffer(long addr, int cap) {
         super(-1, 0, cap, cap);
-        memoryRef = new MemoryRef(addr, this);
+        memoryRef = new MemoryRef(addr, null);
         address = addr;
         cleaner = null;
     }


### PR DESCRIPTION
This is another memory-leak that happens within my setup using the java.nio.* implementation. Just like shown in https://github.com/google/j2objc/issues/2501 it creates cyclic reference between the `DirectByteBuffer` and `MemoryRef`. 

Since the mechanism was created to hold a reference to the original Buffer, after the "live" reference might has been deallocated, this seems not to be a working mechanism in Objective-C.

This change sets the originalBufferObject to always null (like on the other constructor already) to avoid this behavior.
Therefore now the MemoryRef loses its functionality of keeping the DirectByteBuffer's ref. I could not find any negative effects tough, since I am convinced, this can not happen in the transpiled framework anyways.