### PR TITLE
Update GitHub Actions workflow for Java 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,4 @@ jobs:
       
       # Test command-line tools.
       - name: test_tools
-        run: $MAKE_CMD JAVA_HOME=$JAVA_17_HOME test_translator test_cycle_finder test_jre_cycles
+        run: $MAKE_CMD JAVA_HOME=$JAVA_17_HOME test_translator test_cycle_finder


### PR DESCRIPTION
Updates the GitHub Actions configuration to build with Java 17, removed test_jre_cycles from the test command.