### PR TITLE
Fixed translator's Java sources list in public build.

### DIFF
--- a/translator/Makefile
+++ b/translator/Makefile
@@ -236,7 +236,7 @@ JAVA_SOURCES = \
 	translate/SerializationStripper.java \
 	translate/StaticVarRewriter.java \
 	translate/SuperMethodInvocationRewriter.java \
-	translate/SwitchCaseRewriter.java \
+	translate/SwitchConstructRewriter.java \
 	translate/SwitchRewriter.java \
 	translate/UnsequencedExpressionRewriter.java \
 	translate/VarargsRewriter.java \


### PR DESCRIPTION
`translate/SwitchConstructRewriter.java` replaced `translate/SwitchCaseRewriter.java`, so this updates the Make build's sources list.