### PR TITLE
Fixed deprecated NSURLErrorFailingURLStringErrorKey references

### DIFF
--- a/jre_emul/Classes/com/google/j2objc/net/NSErrorException.java
+++ b/jre_emul/Classes/com/google/j2objc/net/NSErrorException.java
@@ -79,7 +79,7 @@ public class NSErrorException extends RuntimeException {
    */
   public native String getFailingURLString() /*-[
     NSDictionary *userInfo = ((NSError *)nsError_).userInfo;
-    return [userInfo objectForKey:NSURLErrorFailingURLStringErrorKey];
+    return [userInfo objectForKey:NSURLErrorFailingURLErrorKey];
   ]-*/;
 
   /**

--- a/jre_emul/misc_tests/com/google/j2objc/net/NSErrorExceptionTest.java
+++ b/jre_emul/misc_tests/com/google/j2objc/net/NSErrorExceptionTest.java
@@ -30,7 +30,7 @@ public class NSErrorExceptionTest extends TestCase {
       [userInfo setObject:description_ forKey:NSLocalizedDescriptionKey];
     }
     if (failingURL) {
-      [userInfo setObject:failingURL forKey:NSURLErrorFailingURLStringErrorKey];
+      [userInfo setObject:failingURL forKey:NSURLErrorFailingURLErrorKey];
     }
     if (underlyingError) {
       [userInfo setObject:underlyingError forKey:NSUnderlyingErrorKey];
@@ -51,7 +51,7 @@ public class NSErrorExceptionTest extends TestCase {
     assertNull("unexpected cause", exception.getCause());
   }
 
-  public void testNextedError() {
+  public void testNestedError() {
     // NSURLErrorSecureConnectionFailed = -1200, NSURLErrorServerCertificateUntrusted = -1202.
     String untrustedDescription = "certificate untrusted";
     String url = "https://0.0.0.0";


### PR DESCRIPTION
Fixed references to deprecated [NSURLErrorFailingURLStringErrorKey](https://developer.apple.com/documentation/foundation/nsurlerrorfailingurlstringerrorkey), updating them to
NSURLErrorFailingURLErrorKey. This fixes the public build with Xcode 26.0.