### PR TITLE
Do not increase pointer after last enum constant

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/EnumRewriter.java
@@ -208,16 +208,17 @@ public class EnumRewriter extends UnitTreeVisitor {
       } else {
         baseTypeCount++;
       }
-
-      initStatements.add(new ExpressionStatement(
-          new CommaExpression(
-              new CastExpression(voidType, new ParenthesizedExpression(
-                  new Assignment(new SimpleName(varElement),
-                  new Assignment(new SimpleName(localEnum),
+      Expression initExpr = new CastExpression(voidType, new ParenthesizedExpression(
+          new Assignment(new SimpleName(varElement),
+              new Assignment(new SimpleName(localEnum),
                   new NativeExpression(
                       UnicodeUtils.format("objc_constructInstance(%s, (void *)ptr)", classExpr),
-                      type.asType()))))),
-              new NativeExpression("ptr += " + sizeName, voidType))));
+                      type.asType())))));
+      if (i < node.getEnumConstants().size() - 1) {
+        initExpr = new CommaExpression(initExpr,
+            new NativeExpression("ptr += " + sizeName, voidType));
+      }
+      initStatements.add(new ExpressionStatement(initExpr));
       String initName = nameTable.getFullFunctionName(methodElement);
       FunctionElement initElement = new FunctionElement(initName, voidType, valueType)
           .addParameters(valueType.asType())

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/EnumRewriterTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/EnumRewriterTest.java
@@ -33,8 +33,8 @@ public class EnumRewriterTest extends GenerationTest {
         "void Test_initWithId_withNSString_withInt_("
             + "Test *self, id t, NSString *__name, int32_t __ordinal) {");
     assertTranslatedLines(translation,
-        "((void) (JreEnum(Test, A) = e = "
-          + "objc_constructInstance(self, (void *)ptr)), ptr += objSize);",
+        "(void) (JreEnum(Test, A) = e = "
+          + "objc_constructInstance(self, (void *)ptr));",
         "Test_initWithId_withNSString_withInt_(e, @\"foo\", @\"A\", 0);");
   }
 
@@ -160,8 +160,8 @@ public class EnumRewriterTest extends GenerationTest {
         "((void) (JreEnum(Test, B) = e = objc_constructInstance([Test_1 class],"
           + " (void *)ptr)), ptr += objSize_B);",
         "Test_1_initWithNSString_withInt_(e, @\"B\", 1);",
-        "((void) (JreEnum(Test, C) = e = "
-          + "objc_constructInstance(self, (void *)ptr)), ptr += objSize);",
+        "(void) (JreEnum(Test, C) = e = "
+          + "objc_constructInstance(self, (void *)ptr));",
         "Test_initWithNSString_withInt_(e, @\"C\", 2);");
   }
 


### PR DESCRIPTION
The last occurence of `ptr += objSize` in enum declaration is redundant and produces warnings with `xcodebuild ... analyze`.

This PR makes sure this extra assignment is skipped.