### PR TITLE
Do not treat Mongolian vowel separator as a whitespace

### DIFF
--- a/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/lang/CharacterTest.java
+++ b/jre_emul/android/platform/libcore/luni/src/test/java/libcore/java/lang/CharacterTest.java
@@ -245,14 +245,7 @@ public class CharacterTest extends junit.framework.TestCase {
     Method m = Character.class.getDeclaredMethod("isSpaceChar" + "Impl", int.class);
     m.setAccessible(true);
     for (int i = 0; i <= 0xffff; ++i) {
-      // ICU and the RI disagree about character 0x180e. Remove this special case if this changes
-      // or Android decides to follow ICU exactly.
-      if (i == 0x180e) {
-        assertTrue(Character.isSpaceChar(i));
-        assertFalse((Boolean) m.invoke(null, i));
-      } else {
-        assertEquals("Failed for character " + i, m.invoke(null, i), Character.isSpaceChar(i));
-      }
+      assertEquals("Failed for character " + i, m.invoke(null, i), Character.isSpaceChar(i));
     }
   }
 
@@ -270,14 +263,7 @@ public class CharacterTest extends junit.framework.TestCase {
     Method m = Character.class.getDeclaredMethod("isWhitespace" + "Impl", int.class);
     m.setAccessible(true);
     for (int i = 0; i <= 0xffff; ++i) {
-      // ICU and the RI disagree about character 0x180e. Remove this special case if this changes
-      // or Android decides to follow ICU exactly.
-      if (i == 0x180e) {
-          assertTrue(Character.isWhitespace(i));
-          assertFalse((Boolean) m.invoke(null, i));
-      } else {
-        assertEquals("Failed for character " + i, m.invoke(null, i), Character.isWhitespace(i));
-      }
+      assertEquals("Failed for character " + i, m.invoke(null, i), Character.isWhitespace(i));
     }
   }
 

--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/java/lang/Character.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/java/lang/Character.java
@@ -7296,8 +7296,8 @@ class Character implements java.io.Serializable, Comparable<Character> {
         if (codePoint < 0x1000) {
             return false;
         }
-        // OGHAM SPACE MARK or MONGOLIAN VOWEL SEPARATOR?
-        if (codePoint == 0x1680 || codePoint == 0x180e) {
+        // OGHAM SPACE MARK?
+        if (codePoint == 0x1680) {
             return true;
         }
         if (codePoint < 0x2000) {
@@ -7393,8 +7393,8 @@ class Character implements java.io.Serializable, Comparable<Character> {
         if (codePoint < 0x1000) {
             return false;
         }
-        // OGHAM SPACE MARK or MONGOLIAN VOWEL SEPARATOR?
-        if (codePoint == 0x1680 || codePoint == 0x180e) {
+        // OGHAM SPACE MARK?
+        if (codePoint == 0x1680) {
             return true;
         }
         if (codePoint < 0x2000) {


### PR DESCRIPTION
As of Java 11 `isWhitespace` for `\u180e` is false.

This aligns the Java emulation with GWT 2.12+
https://github.com/gwtproject/gwt/issues/9973#issuecomment-2214224281