### PR TITLE
Fix two shell script variable-name typos

### DIFF
--- a/scripts/j2objcc.sh
+++ b/scripts/j2objcc.sh
@@ -68,7 +68,7 @@ while [ $# -gt 0 ]; do
     -[cSE]) DO_LINK="no" ;;
     -fobjc-arc) USE_ARC="yes" ;;
     # Check whether we need to build for C++ instead of C.
-    -x) if [ "$2" == "objective-c++" ]; then OBJ_CPP="yes"; fi; shift ;;
+    -x) if [ "$2" == "objective-c++" ]; then OBJC_CPP="yes"; fi; shift ;;
     *.mm) OBJC_CPP="yes";;
     # Save sysroot path for later inspection.
     -isysroot) SYSROOT_PATH="$2"; shift ;;

--- a/scripts/list_framework_libraries.sh
+++ b/scripts/list_framework_libraries.sh
@@ -41,7 +41,7 @@ do
 done
 for platform in $SINGLE_PLATFORMS
 do
-  library=build_result/objs-$platform/lib{LIBRARY_NAME}.a
+  library=build_result/objs-$platform/lib${LIBRARY_NAME}.a
   if [ -f $library ]; then
     echo $library
   fi


### PR DESCRIPTION
### Problem

Two shell script variable-name typos silently break parts of the j2objc build/distribution tooling:

1. **`scripts/list_framework_libraries.sh`** — the single-architecture loop (used for `appletvos` and `appletvsimulator`) constructs the path as `build_result/objs-$platform/lib{LIBRARY_NAME}.a` instead of `lib${LIBRARY_NAME}.a`. The `{...}` form is not expanded, so `[ -f $library ]` never succeeds and tvOS slices are silently dropped from the XCFramework produced by `gen_xcframework.sh` (invoked from `make/framework.mk`).

2. **`scripts/j2objcc.sh`** — the `-x` case sets `OBJ_CPP` (a typo), but the default-standard logic checks `OBJC_CPP`. Passing `-x objective-c++` (the documented way to force ObjC++ for files without a `.mm` extension) therefore falls through to `--std=c17` instead of `--std=c++17`, and ObjC++ code using C++17 constructs fails to compile.

### Verification

- `bash -n` passes on both scripts.
- `list_framework_libraries.sh`: with a mock `build_result/objs-appletvos/libFoo.a` present, the fixed script echoes `build_result/objs-appletvos/libFoo.a`; the unfixed script echoes nothing for the single-arch platforms.
- `j2objcc.sh`: with a stub `xcrun`, `j2objcc -x objective-c++ -c test.cpp` now emits `--std=c++17` (previously `--std=c17`).